### PR TITLE
feat: Dark mode settings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,18 +38,19 @@ export default function App() {
   return (
     <AppContextProvider>
       <Provider store={store}>
-        <GlobalStyles />
-        <BeforeInstallPromptProvider>
-          <UpdateContextProvider>
-            <Router>
-              <IonApp>
-                <Auth>
-                  <TabbedRoutes />
-                </Auth>
-              </IonApp>
-            </Router>
-          </UpdateContextProvider>
-        </BeforeInstallPromptProvider>
+        <GlobalStyles>
+          <BeforeInstallPromptProvider>
+            <UpdateContextProvider>
+              <Router>
+                <IonApp>
+                  <Auth>
+                    <TabbedRoutes />
+                  </Auth>
+                </IonApp>
+              </Router>
+            </UpdateContextProvider>
+          </BeforeInstallPromptProvider>
+        </GlobalStyles>
       </Provider>
     </AppContextProvider>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,8 +16,6 @@ import "@ionic/react/css/text-transformation.css";
 import "@ionic/react/css/flex-utils.css";
 import "@ionic/react/css/display.css";
 
-/* Theme variables */
-import "./theme/variables.css";
 import { Provider } from "react-redux";
 import store from "./store";
 import { isInstalled } from "./helpers/device";

--- a/src/GlobalStyles.tsx
+++ b/src/GlobalStyles.tsx
@@ -1,6 +1,6 @@
 import { Global, ThemeProvider, css } from "@emotion/react";
 import { useAppSelector } from "./store";
-import useDeviceDarkMode from "./helpers/useDeviceDarkMode";
+import useSystemDarkMode from "./helpers/useSystemDarkMode";
 import {
   baseVariables,
   darkVariables,
@@ -13,7 +13,7 @@ interface GlobalStylesProps {
 }
 
 export default function GlobalStyles({ children }: GlobalStylesProps) {
-  const deviceDarkMode = useDeviceDarkMode();
+  const deviceDarkMode = useSystemDarkMode();
   const { fontSizeMultiplier, useSystemFontSize } = useAppSelector(
     (state) => state.appearance.font
   );

--- a/src/GlobalStyles.tsx
+++ b/src/GlobalStyles.tsx
@@ -1,7 +1,14 @@
 import { Global, css } from "@emotion/react";
 import { useAppSelector } from "./store";
+import useDeviceDarkMode from "./helpers/useDeviceDarkMode";
+import {
+  baseVariables,
+  darkVariables,
+  lightVariables,
+} from "./theme/variables";
 
 export default function GlobalStyles() {
+  const systemDarkMode = useDeviceDarkMode();
   const { fontSizeMultiplier, useSystemFontSize } = useAppSelector(
     (state) => state.appearance.font
   );
@@ -14,6 +21,12 @@ export default function GlobalStyles() {
         font-size: ${fontSizeMultiplier}rem;
       `;
 
+  const { userDarkMode, usingDeviceDarkMode } = useAppSelector(
+    (state) => state.appearance.dark
+  );
+
+  const isDark = usingDeviceDarkMode ? systemDarkMode : userDarkMode;
+
   return (
     <Global
       styles={css`
@@ -24,6 +37,10 @@ export default function GlobalStyles() {
             font-size: 1rem;
           }
         }
+
+        ${baseVariables}
+
+        ${isDark ? darkVariables : lightVariables}
       `}
     />
   );

--- a/src/GlobalStyles.tsx
+++ b/src/GlobalStyles.tsx
@@ -1,4 +1,4 @@
-import { Global, css } from "@emotion/react";
+import { Global, ThemeProvider, css } from "@emotion/react";
 import { useAppSelector } from "./store";
 import useDeviceDarkMode from "./helpers/useDeviceDarkMode";
 import {
@@ -6,9 +6,14 @@ import {
   darkVariables,
   lightVariables,
 } from "./theme/variables";
+import React from "react";
 
-export default function GlobalStyles() {
-  const systemDarkMode = useDeviceDarkMode();
+interface GlobalStylesProps {
+  children: React.ReactNode;
+}
+
+export default function GlobalStyles({ children }: GlobalStylesProps) {
+  const deviceDarkMode = useDeviceDarkMode();
   const { fontSizeMultiplier, useSystemFontSize } = useAppSelector(
     (state) => state.appearance.font
   );
@@ -25,23 +30,26 @@ export default function GlobalStyles() {
     (state) => state.appearance.dark
   );
 
-  const isDark = usingDeviceDarkMode ? systemDarkMode : userDarkMode;
+  const isDark = usingDeviceDarkMode ? deviceDarkMode : userDarkMode;
 
   return (
-    <Global
-      styles={css`
-        html {
-          ${baseFontStyles}
+    <ThemeProvider theme={{ dark: isDark }}>
+      <Global
+        styles={css`
+          html {
+            ${baseFontStyles}
 
-          ion-content ion-item {
-            font-size: 1rem;
+            ion-content ion-item {
+              font-size: 1rem;
+            }
           }
-        }
 
-        ${baseVariables}
+          ${baseVariables}
 
-        ${isDark ? darkVariables : lightVariables}
-      `}
-    />
+          ${isDark ? darkVariables : lightVariables}
+        `}
+      />
+      {children}
+    </ThemeProvider>
   );
 }

--- a/src/GlobalStyles.tsx
+++ b/src/GlobalStyles.tsx
@@ -13,7 +13,7 @@ interface GlobalStylesProps {
 }
 
 export default function GlobalStyles({ children }: GlobalStylesProps) {
-  const deviceDarkMode = useSystemDarkMode();
+  const systemDarkMode = useSystemDarkMode();
   const { fontSizeMultiplier, useSystemFontSize } = useAppSelector(
     (state) => state.appearance.font
   );
@@ -26,11 +26,11 @@ export default function GlobalStyles({ children }: GlobalStylesProps) {
         font-size: ${fontSizeMultiplier}rem;
       `;
 
-  const { userDarkMode, usingDeviceDarkMode } = useAppSelector(
+  const { userDarkMode, usingSystemDarkMode } = useAppSelector(
     (state) => state.appearance.dark
   );
 
-  const isDark = usingDeviceDarkMode ? deviceDarkMode : userDarkMode;
+  const isDark = usingSystemDarkMode ? systemDarkMode : userDarkMode;
 
   return (
     <ThemeProvider theme={{ dark: isDark }}>

--- a/src/emotion.d.ts
+++ b/src/emotion.d.ts
@@ -1,0 +1,7 @@
+import "@emotion/react";
+
+declare module "@emotion/react" {
+  export interface Theme {
+    dark: boolean;
+  }
+}

--- a/src/features/comment/Comment.tsx
+++ b/src/features/comment/Comment.tsx
@@ -89,9 +89,11 @@ const Container = styled.div<{ depth: number; highlighted?: boolean }>`
     width: 2px;
     filter: brightness(0.7);
 
-    @media (prefers-color-scheme: light) {
-      filter: none;
-    }
+    ${({ theme }) =>
+      !theme.dark &&
+      css`
+        filter: none;
+      `}
 
     ${({ depth }) =>
       depth &&

--- a/src/features/comment/reply/CommentReply.tsx
+++ b/src/features/comment/reply/CommentReply.tsx
@@ -22,6 +22,7 @@ import useClient from "../../../helpers/useClient";
 import { useAppSelector } from "../../../store";
 import { Centered, Spinner } from "../../auth/Login";
 import { handleSelector, jwtSelector } from "../../auth/authSlice";
+import { css } from "@emotion/react";
 
 export const Container = styled.div`
   position: absolute;
@@ -41,11 +42,13 @@ export const Textarea = styled.textarea`
   flex: 1 0 0;
   min-height: 7rem;
 
-  @media (prefers-color-scheme: light) {
-    .ios & {
-      background: var(--ion-item-background);
-    }
-  }
+  ${({ theme }) =>
+    !theme.dark &&
+    css`
+      .ios & {
+        background: var(--ion-item-background);
+      }
+    `}
 `;
 
 const UsernameIonText = styled(IonText)`

--- a/src/features/inbox/messages/Message.tsx
+++ b/src/features/inbox/messages/Message.tsx
@@ -26,9 +26,11 @@ const Container = styled.div<{ type: "sent" | "recieved" }>`
   --sentColor: var(--ion-color-primary);
   --receiveColor: var(--ion-color-medium);
 
-  @media (prefers-color-scheme: light) {
-    --receiveColor: #eee;
-  }
+  ${({ theme }) =>
+    !theme.dark &&
+    css`
+      --receiveColor: #eee;
+    `}
 
   &:before {
     width: 20px;

--- a/src/features/post/new/NewPostText.tsx
+++ b/src/features/post/new/NewPostText.tsx
@@ -11,6 +11,7 @@ import {
 } from "@ionic/react";
 import { useState } from "react";
 import { Centered, Spinner } from "../../auth/Login";
+import { css } from "@emotion/react";
 
 const Container = styled.div`
   position: absolute;
@@ -30,11 +31,13 @@ const Textarea = styled.textarea`
   flex: 1 0 0;
   min-height: 7rem;
 
-  @media (prefers-color-scheme: light) {
-    .ios & {
-      background: var(--ion-item-background);
-    }
-  }
+  ${({ theme }) =>
+    !theme.dark &&
+    css`
+      .ios & {
+        background: var(--ion-item-background);
+      }
+    `}
 `;
 
 interface NewPostTextProps {

--- a/src/features/settings/appearance/DarkMode.tsx
+++ b/src/features/settings/appearance/DarkMode.tsx
@@ -1,0 +1,71 @@
+import styled from "@emotion/styled";
+import { css } from "@emotion/react";
+import {
+  IonButton,
+  IonLabel,
+  IonList,
+  IonRange,
+  IonToggle,
+} from "@ionic/react";
+import { InsetIonItem } from "../../../pages/profile/ProfileFeedItemsPage";
+import { useAppDispatch, useAppSelector } from "../../../store";
+import { setUserDarkMode, setUseSystemDarkMode } from "./appearanceSlice";
+
+const ListHeader = styled.div`
+  font-size: 0.8em;
+  margin: 32px 0 -8px 32px;
+  text-transform: uppercase;
+  color: var(--ion-color-medium);
+`;
+
+const Range = styled(IonRange)`
+  --bar-background: var(--ion-color-medium);
+
+  ::part(tick) {
+    background: var(--ion-color-medium);
+  }
+`;
+
+const A = styled.div<{ small?: boolean }>`
+  font-size: 1.3em;
+  padding: 0 0.5rem;
+  font-weight: 500;
+
+  ${({ small }) =>
+    small &&
+    css`
+      font-size: 0.8em;
+    `}
+`;
+
+export default function DarkMode() {
+  const dispatch = useAppDispatch();
+  const { userDarkMode, usingDeviceDarkMode: useSystemDarkMode } =
+    useAppSelector((state) => state.appearance.dark);
+
+  return (
+    <>
+      <ListHeader>
+        <IonLabel>System</IonLabel>
+      </ListHeader>
+      <IonList inset>
+        <InsetIonItem>
+          <IonLabel>Use System Light/Dark Mode</IonLabel>
+          <IonToggle
+            checked={useSystemDarkMode}
+            onIonChange={(e) =>
+              dispatch(setUseSystemDarkMode(e.detail.checked))
+            }
+          />
+        </InsetIonItem>
+        <InsetIonItem disabled={useSystemDarkMode}>
+          <IonLabel>Always Use Dark Mode</IonLabel>
+          <IonToggle
+            checked={userDarkMode}
+            onIonChange={(e) => dispatch(setUserDarkMode(e.detail.checked))}
+          />
+        </InsetIonItem>
+      </IonList>
+    </>
+  );
+}

--- a/src/features/settings/appearance/DarkMode.tsx
+++ b/src/features/settings/appearance/DarkMode.tsx
@@ -1,9 +1,9 @@
 import styled from "@emotion/styled";
-import { css } from "@emotion/react";
 import { IonLabel, IonList, IonToggle } from "@ionic/react";
 import { InsetIonItem } from "../../../pages/profile/ProfileFeedItemsPage";
 import { useAppDispatch, useAppSelector } from "../../../store";
-import { setUserDarkMode, setUseSystemDarkMode } from "./appearanceSlice";
+import { setUseSystemDarkMode } from "./appearanceSlice";
+import UserDarkMode from "./UserDarkMode";
 
 const ListHeader = styled.div`
   font-size: 0.8em;
@@ -14,8 +14,9 @@ const ListHeader = styled.div`
 
 export default function DarkMode() {
   const dispatch = useAppDispatch();
-  const { userDarkMode, usingDeviceDarkMode: useSystemDarkMode } =
-    useAppSelector((state) => state.appearance.dark);
+  const { usingDeviceDarkMode } = useAppSelector(
+    (state) => state.appearance.dark
+  );
 
   return (
     <>
@@ -26,20 +27,15 @@ export default function DarkMode() {
         <InsetIonItem>
           <IonLabel>Use System Light/Dark Mode</IonLabel>
           <IonToggle
-            checked={useSystemDarkMode}
+            checked={usingDeviceDarkMode}
             onIonChange={(e) =>
               dispatch(setUseSystemDarkMode(e.detail.checked))
             }
           />
         </InsetIonItem>
-        <InsetIonItem disabled={useSystemDarkMode}>
-          <IonLabel>Always Use Dark Mode</IonLabel>
-          <IonToggle
-            checked={userDarkMode}
-            onIonChange={(e) => dispatch(setUserDarkMode(e.detail.checked))}
-          />
-        </InsetIonItem>
       </IonList>
+
+      {!usingDeviceDarkMode && <UserDarkMode />}
     </>
   );
 }

--- a/src/features/settings/appearance/DarkMode.tsx
+++ b/src/features/settings/appearance/DarkMode.tsx
@@ -1,12 +1,6 @@
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
-import {
-  IonButton,
-  IonLabel,
-  IonList,
-  IonRange,
-  IonToggle,
-} from "@ionic/react";
+import { IonLabel, IonList, IonRange, IonToggle } from "@ionic/react";
 import { InsetIonItem } from "../../../pages/profile/ProfileFeedItemsPage";
 import { useAppDispatch, useAppSelector } from "../../../store";
 import { setUserDarkMode, setUseSystemDarkMode } from "./appearanceSlice";

--- a/src/features/settings/appearance/DarkMode.tsx
+++ b/src/features/settings/appearance/DarkMode.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
-import { IonLabel, IonList, IonRange, IonToggle } from "@ionic/react";
+import { IonLabel, IonList, IonToggle } from "@ionic/react";
 import { InsetIonItem } from "../../../pages/profile/ProfileFeedItemsPage";
 import { useAppDispatch, useAppSelector } from "../../../store";
 import { setUserDarkMode, setUseSystemDarkMode } from "./appearanceSlice";
@@ -10,26 +10,6 @@ const ListHeader = styled.div`
   margin: 32px 0 -8px 32px;
   text-transform: uppercase;
   color: var(--ion-color-medium);
-`;
-
-const Range = styled(IonRange)`
-  --bar-background: var(--ion-color-medium);
-
-  ::part(tick) {
-    background: var(--ion-color-medium);
-  }
-`;
-
-const A = styled.div<{ small?: boolean }>`
-  font-size: 1.3em;
-  padding: 0 0.5rem;
-  font-weight: 500;
-
-  ${({ small }) =>
-    small &&
-    css`
-      font-size: 0.8em;
-    `}
 `;
 
 export default function DarkMode() {

--- a/src/features/settings/appearance/DarkMode.tsx
+++ b/src/features/settings/appearance/DarkMode.tsx
@@ -14,7 +14,7 @@ const ListHeader = styled.div`
 
 export default function DarkMode() {
   const dispatch = useAppDispatch();
-  const { usingDeviceDarkMode } = useAppSelector(
+  const { usingSystemDarkMode } = useAppSelector(
     (state) => state.appearance.dark
   );
 
@@ -27,7 +27,7 @@ export default function DarkMode() {
         <InsetIonItem>
           <IonLabel>Use System Light/Dark Mode</IonLabel>
           <IonToggle
-            checked={usingDeviceDarkMode}
+            checked={usingSystemDarkMode}
             onIonChange={(e) =>
               dispatch(setUseSystemDarkMode(e.detail.checked))
             }
@@ -35,7 +35,7 @@ export default function DarkMode() {
         </InsetIonItem>
       </IonList>
 
-      {!usingDeviceDarkMode && <UserDarkMode />}
+      {!usingSystemDarkMode && <UserDarkMode />}
     </>
   );
 }

--- a/src/features/settings/appearance/UserDarkMode.tsx
+++ b/src/features/settings/appearance/UserDarkMode.tsx
@@ -13,7 +13,9 @@ const ListHeader = styled.div`
 
 export default function UserDarkMode() {
   const dispatch = useAppDispatch();
-  const { userDarkMode } = useAppSelector((state) => state.appearance.dark);
+  const userDarkMode = useAppSelector(
+    (state) => state.appearance.dark.userDarkMode
+  );
 
   return (
     <>
@@ -27,11 +29,11 @@ export default function UserDarkMode() {
         >
           <InsetIonItem>
             <IonLabel>Light</IonLabel>
-            <IonRadio value="light" />
+            <IonRadio value={false} />
           </InsetIonItem>
           <InsetIonItem>
             <IonLabel>Dark</IonLabel>
-            <IonRadio value="dark" />
+            <IonRadio value={true} />
           </InsetIonItem>
         </IonRadioGroup>
       </IonList>

--- a/src/features/settings/appearance/UserDarkMode.tsx
+++ b/src/features/settings/appearance/UserDarkMode.tsx
@@ -23,10 +23,7 @@ export default function UserDarkMode() {
       <IonList inset>
         <IonRadioGroup
           value={userDarkMode}
-          onIonChange={(e) => {
-            console.log(e.detail.value);
-            dispatch(setUserDarkMode(e.detail.value));
-          }}
+          onIonChange={(e) => dispatch(setUserDarkMode(e.detail.value))}
         >
           <InsetIonItem>
             <IonLabel>Light</IonLabel>

--- a/src/features/settings/appearance/UserDarkMode.tsx
+++ b/src/features/settings/appearance/UserDarkMode.tsx
@@ -1,0 +1,43 @@
+import styled from "@emotion/styled";
+import { IonLabel, IonList, IonRadio, IonRadioGroup } from "@ionic/react";
+import { InsetIonItem } from "../../../pages/profile/ProfileFeedItemsPage";
+import { useAppDispatch, useAppSelector } from "../../../store";
+import { setUserDarkMode } from "./appearanceSlice";
+
+const ListHeader = styled.div`
+  font-size: 0.8em;
+  margin: 32px 0 -8px 32px;
+  text-transform: uppercase;
+  color: var(--ion-color-medium);
+`;
+
+export default function UserDarkMode() {
+  const dispatch = useAppDispatch();
+  const { userDarkMode } = useAppSelector((state) => state.appearance.dark);
+
+  return (
+    <>
+      <ListHeader>
+        <IonLabel>Light/Dark Mode</IonLabel>
+      </ListHeader>
+      <IonList inset>
+        <IonRadioGroup
+          value={userDarkMode}
+          onIonChange={(e) => {
+            console.log(e.detail.value);
+            dispatch(setUserDarkMode(e.detail.value));
+          }}
+        >
+          <InsetIonItem>
+            <IonLabel>Light</IonLabel>
+            <IonRadio value="light" />
+          </InsetIonItem>
+          <InsetIonItem>
+            <IonLabel>Dark</IonLabel>
+            <IonRadio value="dark" />
+          </InsetIonItem>
+        </IonRadioGroup>
+      </IonList>
+    </>
+  );
+}

--- a/src/features/settings/appearance/UserDarkMode.tsx
+++ b/src/features/settings/appearance/UserDarkMode.tsx
@@ -22,11 +22,11 @@ export default function UserDarkMode() {
       <ListHeader>
         <IonLabel>Light/Dark Mode</IonLabel>
       </ListHeader>
-      <IonList inset>
-        <IonRadioGroup
-          value={userDarkMode}
-          onIonChange={(e) => dispatch(setUserDarkMode(e.detail.value))}
-        >
+      <IonRadioGroup
+        value={userDarkMode}
+        onIonChange={(e) => dispatch(setUserDarkMode(e.detail.value))}
+      >
+        <IonList inset>
           <InsetIonItem>
             <IonLabel>Light</IonLabel>
             <IonRadio value={false} />
@@ -35,8 +35,8 @@ export default function UserDarkMode() {
             <IonLabel>Dark</IonLabel>
             <IonRadio value={true} />
           </InsetIonItem>
-        </IonRadioGroup>
-      </IonList>
+        </IonList>
+      </IonRadioGroup>
     </>
   );
 }

--- a/src/features/settings/appearance/appearanceSlice.tsx
+++ b/src/features/settings/appearance/appearanceSlice.tsx
@@ -10,6 +10,10 @@ const STORAGE_KEYS = {
   POSTS: {
     TYPE: "appearance--post-type",
   },
+  DARK: {
+    USE_SYSTEM: "appearance--dark-use-system",
+    USER_MODE: "appearance--dark-user-mode",
+  },
 } as const;
 
 export const OPostAppearanceType = {
@@ -28,6 +32,10 @@ interface AppearanceState {
   posts: {
     type: PostAppearanceType;
   };
+  dark: {
+    usingDeviceDarkMode: boolean;
+    userDarkMode: boolean;
+  };
 }
 
 const initialState: AppearanceState = {
@@ -38,6 +46,10 @@ const initialState: AppearanceState = {
   posts: {
     type: "large",
   },
+  dark: {
+    usingDeviceDarkMode: true,
+    userDarkMode: false,
+  },
 };
 
 const stateFromStorage: AppearanceState = merge(initialState, {
@@ -47,6 +59,10 @@ const stateFromStorage: AppearanceState = merge(initialState, {
   },
   posts: {
     type: get(STORAGE_KEYS.POSTS.TYPE),
+  },
+  dark: {
+    userDarkMode: get(STORAGE_KEYS.DARK.USER_MODE),
+    useSystemDarkMode: get(STORAGE_KEYS.DARK.USE_SYSTEM),
   },
 });
 
@@ -69,6 +85,16 @@ export const appearanceSlice = createSlice({
 
       set(STORAGE_KEYS.POSTS.TYPE, action.payload);
     },
+    setUserDarkMode(state, action: PayloadAction<boolean>) {
+      state.dark.userDarkMode = action.payload;
+
+      set(STORAGE_KEYS.DARK.USER_MODE, action.payload);
+    },
+    setUseSystemDarkMode(state, action: PayloadAction<boolean>) {
+      state.dark.usingDeviceDarkMode = action.payload;
+
+      set(STORAGE_KEYS.DARK.USE_SYSTEM, action.payload);
+    },
 
     resetAppearance: () => initialState,
   },
@@ -78,6 +104,8 @@ export const {
   setFontSizeMultiplier,
   setUseSystemFontSize,
   setPostAppearance,
+  setUserDarkMode,
+  setUseSystemDarkMode,
 } = appearanceSlice.actions;
 
 export default appearanceSlice.reducer;

--- a/src/features/settings/appearance/appearanceSlice.tsx
+++ b/src/features/settings/appearance/appearanceSlice.tsx
@@ -55,14 +55,14 @@ const initialState: AppearanceState = {
 const stateFromStorage: AppearanceState = merge(initialState, {
   font: {
     fontSizeMultiplier: get(STORAGE_KEYS.FONT.FONT_SIZE_MULTIPLIER),
-    useSystemFontSize: get(STORAGE_KEYS.FONT.USE_SYSTEM),
+    usingDeviceDarkMode: get(STORAGE_KEYS.FONT.USE_SYSTEM),
   },
   posts: {
     type: get(STORAGE_KEYS.POSTS.TYPE),
   },
   dark: {
+    usingDeviceDarkMode: get(STORAGE_KEYS.DARK.USE_SYSTEM),
     userDarkMode: get(STORAGE_KEYS.DARK.USER_MODE),
-    useSystemDarkMode: get(STORAGE_KEYS.DARK.USE_SYSTEM),
   },
 });
 

--- a/src/features/settings/appearance/appearanceSlice.tsx
+++ b/src/features/settings/appearance/appearanceSlice.tsx
@@ -55,13 +55,13 @@ const initialState: AppearanceState = {
 const stateFromStorage: AppearanceState = merge(initialState, {
   font: {
     fontSizeMultiplier: get(STORAGE_KEYS.FONT.FONT_SIZE_MULTIPLIER),
-    usingDeviceDarkMode: get(STORAGE_KEYS.FONT.USE_SYSTEM),
+    useSystemFontSize: get(STORAGE_KEYS.FONT.USE_SYSTEM),
   },
   posts: {
     type: get(STORAGE_KEYS.POSTS.TYPE),
   },
   dark: {
-    usingDeviceDarkMode: get(STORAGE_KEYS.DARK.USE_SYSTEM),
+    usingSystemDarkMode: get(STORAGE_KEYS.DARK.USE_SYSTEM),
     userDarkMode: get(STORAGE_KEYS.DARK.USER_MODE),
   },
 });

--- a/src/features/settings/appearance/appearanceSlice.tsx
+++ b/src/features/settings/appearance/appearanceSlice.tsx
@@ -33,7 +33,7 @@ interface AppearanceState {
     type: PostAppearanceType;
   };
   dark: {
-    usingDeviceDarkMode: boolean;
+    usingSystemDarkMode: boolean;
     userDarkMode: boolean;
   };
 }
@@ -47,7 +47,7 @@ const initialState: AppearanceState = {
     type: "large",
   },
   dark: {
-    usingDeviceDarkMode: true,
+    usingSystemDarkMode: true,
     userDarkMode: false,
   },
 };
@@ -91,7 +91,7 @@ export const appearanceSlice = createSlice({
       set(STORAGE_KEYS.DARK.USER_MODE, action.payload);
     },
     setUseSystemDarkMode(state, action: PayloadAction<boolean>) {
-      state.dark.usingDeviceDarkMode = action.payload;
+      state.dark.usingSystemDarkMode = action.payload;
 
       set(STORAGE_KEYS.DARK.USE_SYSTEM, action.payload);
     },

--- a/src/helpers/useDeviceDarkMode.ts
+++ b/src/helpers/useDeviceDarkMode.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+
+export default function useDeviceDarkMode() {
+  const [prefersDarkMode, setPrefersDarkMode] = useState(
+    window.matchMedia("(prefers-color-scheme: dark)").matches
+  );
+
+  useEffect(() => {
+    function handleDarkModePrefferedChange() {
+      const doesMatch = window.matchMedia(
+        "(prefers-color-scheme: dark)"
+      ).matches;
+      setPrefersDarkMode(doesMatch);
+    }
+
+    window
+      .matchMedia("(prefers-color-scheme: dark)")
+      .addEventListener("change", handleDarkModePrefferedChange);
+
+    return () => {
+      window
+        .matchMedia("(prefers-color-scheme: dark)")
+        .removeEventListener("change", handleDarkModePrefferedChange);
+    };
+  }, []);
+
+  return prefersDarkMode;
+}

--- a/src/helpers/useDeviceDarkMode.ts
+++ b/src/helpers/useDeviceDarkMode.ts
@@ -1,26 +1,26 @@
 import { useEffect, useState } from "react";
 
+const DARK_MEDIA_SELECTOR = "(prefers-color-scheme: dark)";
+
 export default function useDeviceDarkMode() {
   const [prefersDarkMode, setPrefersDarkMode] = useState(
-    window.matchMedia("(prefers-color-scheme: dark)").matches
+    window.matchMedia(DARK_MEDIA_SELECTOR).matches
   );
 
   useEffect(() => {
-    function handleDarkModePrefferedChange() {
-      const doesMatch = window.matchMedia(
-        "(prefers-color-scheme: dark)"
-      ).matches;
+    function handleDarkModeChange() {
+      const doesMatch = window.matchMedia(DARK_MEDIA_SELECTOR).matches;
       setPrefersDarkMode(doesMatch);
     }
 
     window
-      .matchMedia("(prefers-color-scheme: dark)")
-      .addEventListener("change", handleDarkModePrefferedChange);
+      .matchMedia(DARK_MEDIA_SELECTOR)
+      .addEventListener("change", handleDarkModeChange);
 
     return () => {
       window
-        .matchMedia("(prefers-color-scheme: dark)")
-        .removeEventListener("change", handleDarkModePrefferedChange);
+        .matchMedia(DARK_MEDIA_SELECTOR)
+        .removeEventListener("change", handleDarkModeChange);
     };
   }, []);
 

--- a/src/helpers/useSystemDarkMode.ts
+++ b/src/helpers/useSystemDarkMode.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 
 const DARK_MEDIA_SELECTOR = "(prefers-color-scheme: dark)";
 
-export default function useDeviceDarkMode() {
+export default function useSystemDarkMode() {
   const [prefersDarkMode, setPrefersDarkMode] = useState(
     window.matchMedia(DARK_MEDIA_SELECTOR).matches
   );

--- a/src/index.css
+++ b/src/index.css
@@ -18,24 +18,6 @@ ion-tab-button {
   justify-content: flex-start;
 }
 
-@media (prefers-color-scheme: light) {
-  .ios .grey-bg {
-    --ion-background-color: var(--ion-color-step-50, #f2f2f7);
-  }
-  .ios .grey-bg ion-header {
-    --opacity: 0;
-  }
-  .ios .grey-bg ion-modal ion-content {
-    --background: #fff;
-  }
-  .ios .grey-bg ion-item {
-    --ion-background-color: #fff;
-  }
-  .ios .grey-bg ion-item-sliding {
-    background: #fff;
-  }
-}
-
 ion-modal.small {
   --height: 50%;
   --width: 85%;

--- a/src/pages/settings/AppearancePage.tsx
+++ b/src/pages/settings/AppearancePage.tsx
@@ -9,6 +9,7 @@ import {
 import AppContent from "../../features/shared/AppContent";
 import TextSize from "../../features/settings/appearance/TextSize";
 import PostView from "../../features/settings/appearance/PostView";
+import DarkMode from "../../features/settings/appearance/DarkMode";
 
 export default function AppearancePage() {
   return (
@@ -25,6 +26,7 @@ export default function AppearancePage() {
       <AppContent scrollY>
         <TextSize />
         <PostView />
+        <DarkMode />
       </AppContent>
     </IonPage>
   );

--- a/src/theme/variables.ts
+++ b/src/theme/variables.ts
@@ -1,108 +1,126 @@
-/* Ionic Variables and Theming. For more info, please see:
-http://ionicframework.com/docs/theming/ */
+import { css } from "@emotion/react";
 
-/** Ionic CSS Variables **/
-:root {
-  --ion-text-color: #000;
+export const baseVariables = css`
+  // Ionic Variables and Theming. For more info, please see:
+  // http://ionicframework.com/docs/theming/
 
-  /** primary **/
-  --ion-color-primary: #3880ff;
-  --ion-color-primary-rgb: 56, 128, 255;
-  --ion-color-primary-contrast: #ffffff;
-  --ion-color-primary-contrast-rgb: 255, 255, 255;
-  --ion-color-primary-shade: #3171e0;
-  --ion-color-primary-tint: #4c8dff;
+  // Ionic CSS Variables
+  :root {
+    --ion-text-color: #000;
 
-  /** secondary **/
-  --ion-color-secondary: #3dc2ff;
-  --ion-color-secondary-rgb: 61, 194, 255;
-  --ion-color-secondary-contrast: #ffffff;
-  --ion-color-secondary-contrast-rgb: 255, 255, 255;
-  --ion-color-secondary-shade: #36abe0;
-  --ion-color-secondary-tint: #50c8ff;
+    /** primary **/
+    --ion-color-primary: #3880ff;
+    --ion-color-primary-rgb: 56, 128, 255;
+    --ion-color-primary-contrast: #ffffff;
+    --ion-color-primary-contrast-rgb: 255, 255, 255;
+    --ion-color-primary-shade: #3171e0;
+    --ion-color-primary-tint: #4c8dff;
 
-  /** tertiary **/
-  --ion-color-tertiary: #5260ff;
-  --ion-color-tertiary-rgb: 82, 96, 255;
-  --ion-color-tertiary-contrast: #ffffff;
-  --ion-color-tertiary-contrast-rgb: 255, 255, 255;
-  --ion-color-tertiary-shade: #4854e0;
-  --ion-color-tertiary-tint: #6370ff;
+    /** secondary **/
+    --ion-color-secondary: #3dc2ff;
+    --ion-color-secondary-rgb: 61, 194, 255;
+    --ion-color-secondary-contrast: #ffffff;
+    --ion-color-secondary-contrast-rgb: 255, 255, 255;
+    --ion-color-secondary-shade: #36abe0;
+    --ion-color-secondary-tint: #50c8ff;
 
-  /** success **/
-  --ion-color-success: #2dd36f;
-  --ion-color-success-rgb: 45, 211, 111;
-  --ion-color-success-contrast: #ffffff;
-  --ion-color-success-contrast-rgb: 255, 255, 255;
-  --ion-color-success-shade: #28ba62;
-  --ion-color-success-tint: #42d77d;
+    /** tertiary **/
+    --ion-color-tertiary: #5260ff;
+    --ion-color-tertiary-rgb: 82, 96, 255;
+    --ion-color-tertiary-contrast: #ffffff;
+    --ion-color-tertiary-contrast-rgb: 255, 255, 255;
+    --ion-color-tertiary-shade: #4854e0;
+    --ion-color-tertiary-tint: #6370ff;
 
-  /** warning **/
-  --ion-color-warning: #ffc409;
-  --ion-color-warning-rgb: 255, 196, 9;
-  --ion-color-warning-contrast: #000000;
-  --ion-color-warning-contrast-rgb: 0, 0, 0;
-  --ion-color-warning-shade: #e0ac08;
-  --ion-color-warning-tint: #ffca22;
+    /** success **/
+    --ion-color-success: #2dd36f;
+    --ion-color-success-rgb: 45, 211, 111;
+    --ion-color-success-contrast: #ffffff;
+    --ion-color-success-contrast-rgb: 255, 255, 255;
+    --ion-color-success-shade: #28ba62;
+    --ion-color-success-tint: #42d77d;
 
-  /** danger **/
-  --ion-color-danger: #eb445a;
-  --ion-color-danger-rgb: 235, 68, 90;
-  --ion-color-danger-contrast: #ffffff;
-  --ion-color-danger-contrast-rgb: 255, 255, 255;
-  --ion-color-danger-shade: #cf3c4f;
-  --ion-color-danger-tint: #ed576b;
+    /** warning **/
+    --ion-color-warning: #ffc409;
+    --ion-color-warning-rgb: 255, 196, 9;
+    --ion-color-warning-contrast: #000000;
+    --ion-color-warning-contrast-rgb: 0, 0, 0;
+    --ion-color-warning-shade: #e0ac08;
+    --ion-color-warning-tint: #ffca22;
 
-  /** dark **/
-  --ion-color-dark: #222428;
-  --ion-color-dark-rgb: 34, 36, 40;
-  --ion-color-dark-contrast: #ffffff;
-  --ion-color-dark-contrast-rgb: 255, 255, 255;
-  --ion-color-dark-shade: #1e2023;
-  --ion-color-dark-tint: #383a3e;
+    /** danger **/
+    --ion-color-danger: #eb445a;
+    --ion-color-danger-rgb: 235, 68, 90;
+    --ion-color-danger-contrast: #ffffff;
+    --ion-color-danger-contrast-rgb: 255, 255, 255;
+    --ion-color-danger-shade: #cf3c4f;
+    --ion-color-danger-tint: #ed576b;
 
-  /** medium **/
-  --ion-color-medium: #92949c;
-  --ion-color-medium-rgb: 146, 148, 156;
-  --ion-color-medium-contrast: #ffffff;
-  --ion-color-medium-contrast-rgb: 255, 255, 255;
-  --ion-color-medium-shade: #808289;
-  --ion-color-medium-tint: #9d9fa6;
+    /** dark **/
+    --ion-color-dark: #222428;
+    --ion-color-dark-rgb: 34, 36, 40;
+    --ion-color-dark-contrast: #ffffff;
+    --ion-color-dark-contrast-rgb: 255, 255, 255;
+    --ion-color-dark-shade: #1e2023;
+    --ion-color-dark-tint: #383a3e;
 
-  --ion-color-medium2: var(--ion-color-medium);
+    /** medium **/
+    --ion-color-medium: #92949c;
+    --ion-color-medium-rgb: 146, 148, 156;
+    --ion-color-medium-contrast: #ffffff;
+    --ion-color-medium-contrast-rgb: 255, 255, 255;
+    --ion-color-medium-shade: #808289;
+    --ion-color-medium-tint: #9d9fa6;
 
-  /** light **/
-  --ion-color-light: #f4f5f8;
-  --ion-color-light-rgb: 244, 245, 248;
-  --ion-color-light-contrast: #000000;
-  --ion-color-light-contrast-rgb: 0, 0, 0;
-  --ion-color-light-shade: #d7d8da;
-  --ion-color-light-tint: #f5f6f9;
+    --ion-color-medium2: var(--ion-color-medium);
 
-  --lightroom-bg: rgba(0, 0, 0, 0.08);
+    /** light **/
+    --ion-color-light: #f4f5f8;
+    --ion-color-light-rgb: 244, 245, 248;
+    --ion-color-light-contrast: #000000;
+    --ion-color-light-contrast-rgb: 0, 0, 0;
+    --ion-color-light-shade: #d7d8da;
+    --ion-color-light-tint: #f5f6f9;
 
-  --thick-separator-color: var(--ion-color-step-50, #f2f2f7);
+    --lightroom-bg: rgba(0, 0, 0, 0.08);
 
-  --ion-color-step-100: #f3f3f3;
+    --thick-separator-color: var(--ion-color-step-50, #f2f2f7);
 
-  --unread-item-background-color: #fffcd9;
-}
+    --ion-color-step-100: #f3f3f3;
 
-.ios body {
-  --ion-background-color: #fff;
-}
+    --unread-item-background-color: #fffcd9;
+  }
 
-.ios ion-modal {
-  --ion-background-color: var(--ion-color-step-50, #f2f2f7);
-  --ion-item-background: #fff;
-}
+  .ios body {
+    --ion-background-color: #fff;
+  }
 
-@media (prefers-color-scheme: dark) {
-  /*
-   * Dark Colors
-   * -------------------------------------------
-   */
+  .ios ion-modal {
+    --ion-background-color: var(--ion-color-step-50, #f2f2f7);
+    --ion-item-background: #fff;
+  }
+`;
 
+export const lightVariables = css`
+  :root.ios .grey-bg {
+    --ion-background-color: var(--ion-color-step-50, #f2f2f7);
+  }
+  :root.ios .grey-bg ion-header {
+    --opacity: 0;
+  }
+  :root.ios .grey-bg ion-modal ion-content {
+    --background: #fff;
+  }
+  :root.ios .grey-bg ion-item {
+    --ion-background-color: #fff;
+  }
+  :root.ios .grey-bg ion-item-sliding {
+    background: #fff;
+  }
+`;
+
+export const darkVariables = css`
+  // Dark Colors
   :root {
     --lightroom-bg: rgba(255, 255, 255, 0.08);
   }
@@ -178,10 +196,7 @@ http://ionicframework.com/docs/theming/ */
     --unread-item-background-color: #1e1c00;
   }
 
-  /*
-   * iOS Dark Theme
-   * -------------------------------------------
-   */
+  // iOS Dark Theme
 
   .ios body {
     --ion-background-color: #000000;
@@ -224,10 +239,7 @@ http://ionicframework.com/docs/theming/ */
     --ion-item-background: var(--ion-color-step-50);
   }
 
-  /*
-   * Material Design Dark Theme
-   * -------------------------------------------
-   */
+  // Material Design Dark Theme
 
   .md body {
     --ion-background-color: #121212;
@@ -266,12 +278,12 @@ http://ionicframework.com/docs/theming/ */
 
     --ion-card-background: #1e1e1e;
   }
-}
 
-@media (prefers-color-scheme: dark) and (max-width: 767px) {
-  .ios ion-modal:not(.small) {
-    --ion-background-color: #000;
-    --ion-toolbar-background: var(--ion-background-color);
-    --ion-toolbar-border-color: var(--ion-color-step-150);
+  @media (max-width: 767px) {
+    .ios ion-modal:not(.small) {
+      --ion-background-color: #000;
+      --ion-toolbar-background: var(--ion-background-color);
+      --ion-toolbar-border-color: var(--ion-color-step-150);
+    }
   }
-}
+`;


### PR DESCRIPTION
Adds two toggles to the Settings > Appearance page
1. Whether or not to obey the system value for light/dark mode
2. If user chooses not to use the system value, whether or not to always use dark mode

<img width="711" alt="toggles" src="https://github.com/aeharding/wefwef/assets/9542314/e02e87a9-000a-4e4a-bf0d-10ccceeac3fb">
<img width="709" alt="toggles2" src="https://github.com/aeharding/wefwef/assets/9542314/73585545-7e99-44e0-ab54-f8f4a7aac347">

Code Details:
- Changed CSS to rely on class based dark mode theming rather than media query alone
- Implemented logic to store and update toggle values from settings screen
- Implemented change detection for system dark/light theme if toggle is enabled