### PR TITLE
feat: segregate community list alphabetically

### DIFF
--- a/src/pages/posts/CommunitiesPage.tsx
+++ b/src/pages/posts/CommunitiesPage.tsx
@@ -18,11 +18,12 @@ import { home, library, people } from "ionicons/icons";
 import styled from "@emotion/styled";
 import { pullAllBy, sortBy, uniqBy } from "lodash";
 import { notEmpty } from "../../helpers/array";
-import { useMemo, useRef } from "react";
+import { Fragment, useMemo, useRef } from "react";
 import { useSetActivePage } from "../../features/auth/AppContext";
 import { useBuildGeneralBrowseLink } from "../../helpers/routes";
 import ItemIcon from "../../features/labels/img/ItemIcon";
 import { jwtSelector } from "../../features/auth/authSlice";
+import { Community } from "lemmy-js-client";
 
 const SubIcon = styled(IonIcon)<{ color: string }>`
   border-radius: 50%;
@@ -125,23 +126,42 @@ export default function CommunitiesPage() {
             </IonItem>
           </IonItemGroup>
 
-          <IonItemGroup>
-            <IonItemDivider>
-              <IonLabel>Communities</IonLabel>
-            </IonItemDivider>
-          </IonItemGroup>
-
-          {sortBy(communities, "name")?.map((community) => (
-            <IonItem
-              key={community.id}
-              routerLink={buildGeneralBrowseLink(`/c/${getHandle(community)}`)}
-            >
-              <Content>
-                <ItemIcon item={community} size={28} />
-                {getHandle(community)}
-              </Content>
-            </IonItem>
-          ))}
+          <div>
+            {Object.entries(
+              sortBy(communities, (c) => c.name.toLowerCase()).reduce(
+                (acc, community) => {
+                  const firstLetter = community.name[0].toUpperCase();
+                  if (!acc[firstLetter]) {
+                    acc[firstLetter] = [];
+                  }
+                  acc[firstLetter].push(community);
+                  return acc;
+                },
+                {} as Record<string, Community[]>
+              )
+            ).map(([letter, communities]) => (
+              <Fragment key={letter}>
+                <IonItemGroup>
+                  <IonItemDivider>
+                    <IonLabel>{letter}</IonLabel>
+                  </IonItemDivider>
+                </IonItemGroup>
+                {communities.map((community) => (
+                  <IonItem
+                    key={community.id}
+                    routerLink={buildGeneralBrowseLink(
+                      `/c/${getHandle(community)}`
+                    )}
+                  >
+                    <Content>
+                      <ItemIcon item={community} size={28} />
+                      {getHandle(community)}
+                    </Content>
+                  </IonItem>
+                ))}
+              </Fragment>
+            ))}
+          </div>
         </IonList>
       </AppContent>
     </IonPage>

--- a/src/pages/posts/CommunitiesPage.tsx
+++ b/src/pages/posts/CommunitiesPage.tsx
@@ -87,6 +87,10 @@ export default function CommunitiesPage() {
     return communities;
   }, [follows, communityByHandle]);
 
+  const alphabeticallySortedCommunities = useMemo(() => {
+    return sortBy(communities, (c) => c.name.toLowerCase());
+  }, [communities]);
+
   return (
     <IonPage ref={pageRef}>
       <IonHeader>
@@ -128,17 +132,14 @@ export default function CommunitiesPage() {
 
           <div>
             {Object.entries(
-              sortBy(communities, (c) => c.name.toLowerCase()).reduce(
-                (acc, community) => {
-                  const firstLetter = community.name[0].toUpperCase();
-                  if (!acc[firstLetter]) {
-                    acc[firstLetter] = [];
-                  }
-                  acc[firstLetter].push(community);
-                  return acc;
-                },
-                {} as Record<string, Community[]>
-              )
+              alphabeticallySortedCommunities.reduce((acc, community) => {
+                const firstLetter = community.name[0].toUpperCase();
+                if (!acc[firstLetter]) {
+                  acc[firstLetter] = [];
+                }
+                acc[firstLetter].push(community);
+                return acc;
+              }, {} as Record<string, Community[]>)
             ).map(([letter, communities]) => (
               <Fragment key={letter}>
                 <IonItemGroup>

--- a/src/pages/posts/CommunitiesPage.tsx
+++ b/src/pages/posts/CommunitiesPage.tsx
@@ -87,8 +87,24 @@ export default function CommunitiesPage() {
     return communities;
   }, [follows, communityByHandle]);
 
-  const alphabeticallySortedCommunities = useMemo(() => {
-    return sortBy(communities, (c) => c.name.toLowerCase());
+  const communitiesGroupedByLetter = useMemo(() => {
+    const alphabeticallySortedCommunities = sortBy(communities, (c) =>
+      c.name.toLowerCase()
+    );
+
+    return Object.entries(
+      alphabeticallySortedCommunities.reduce<Record<string, Community[]>>(
+        (acc, community) => {
+          const firstLetter = community.name[0].toUpperCase();
+          if (!acc[firstLetter]) {
+            acc[firstLetter] = [];
+          }
+          acc[firstLetter].push(community);
+          return acc;
+        },
+        {}
+      )
+    );
   }, [communities]);
 
   return (
@@ -130,39 +146,28 @@ export default function CommunitiesPage() {
             </IonItem>
           </IonItemGroup>
 
-          <div>
-            {Object.entries(
-              alphabeticallySortedCommunities.reduce((acc, community) => {
-                const firstLetter = community.name[0].toUpperCase();
-                if (!acc[firstLetter]) {
-                  acc[firstLetter] = [];
-                }
-                acc[firstLetter].push(community);
-                return acc;
-              }, {} as Record<string, Community[]>)
-            ).map(([letter, communities]) => (
-              <Fragment key={letter}>
-                <IonItemGroup>
-                  <IonItemDivider>
-                    <IonLabel>{letter}</IonLabel>
-                  </IonItemDivider>
-                </IonItemGroup>
-                {communities.map((community) => (
-                  <IonItem
-                    key={community.id}
-                    routerLink={buildGeneralBrowseLink(
-                      `/c/${getHandle(community)}`
-                    )}
-                  >
-                    <Content>
-                      <ItemIcon item={community} size={28} />
-                      {getHandle(community)}
-                    </Content>
-                  </IonItem>
-                ))}
-              </Fragment>
-            ))}
-          </div>
+          {communitiesGroupedByLetter.map(([letter, communities]) => (
+            <Fragment key={letter}>
+              <IonItemGroup>
+                <IonItemDivider>
+                  <IonLabel>{letter}</IonLabel>
+                </IonItemDivider>
+              </IonItemGroup>
+              {communities.map((community) => (
+                <IonItem
+                  key={community.id}
+                  routerLink={buildGeneralBrowseLink(
+                    `/c/${getHandle(community)}`
+                  )}
+                >
+                  <Content>
+                    <ItemIcon item={community} size={28} />
+                    {getHandle(community)}
+                  </Content>
+                </IonItem>
+              ))}
+            </Fragment>
+          ))}
         </IonList>
       </AppContent>
     </IonPage>


### PR DESCRIPTION
In Apollo, the community list is sorted alphabetically but also separated by their starting letter. This makes it much clearer and easier to find communities in long lists.

Comparison (Apollo first, Wefwef second):
![Screenshot 2023-06-29 at 18 33 36](https://github.com/aeharding/wefwef/assets/51917118/6520e635-0bcf-432e-9745-bce0beff8521)
![Screenshot 2023-06-29 at 18 33 53](https://github.com/aeharding/wefwef/assets/51917118/44886883-7313-436c-8d95-e07c998fbccd)

