### PR TITLE
Add emergency hotfix for rejected connections to lemmy.world

### DIFF
--- a/src/services/lemmy.ts
+++ b/src/services/lemmy.ts
@@ -1,6 +1,10 @@
 import { LemmyHttp } from "lemmy-js-client";
 
 function buildBaseUrl(url: string): string {
+  if (url === "lemmy.world") {
+    return `https://lemmy.world`;
+  }
+
   return `${location.origin}/api/${url}`;
 }
 


### PR DESCRIPTION
Background:

Yesterday, reverse proxied requests on lemmy.app started being rejected from wefwef.app due to rate limiting built into lemmy on lemmy.world due to a sustantial increase in traffic over the last 48 hours.

lemmy.world will shortly enable CORS.

Note: This hotfix may only be deployed to wefwef.app.

Future versions of lemmy will enable CORS * by default like Mastodon, which will completely resolve this issue.