### PR TITLE
Typo fix on new post popup

### DIFF
--- a/src/features/post/new/NewPostRoot.tsx
+++ b/src/features/post/new/NewPostRoot.tsx
@@ -198,7 +198,7 @@ export default function NewPostRoot({
     }
 
     present({
-      message: "Posted created!",
+      message: "Post created!",
       duration: 3500,
       position: "bottom",
       color: "success",


### PR DESCRIPTION
Just a small fix - I noticed that when you make a new post the popup would say "Posted created!".  Updated it to "Post created!".