### PR TITLE
feat: Select text modals

### DIFF
--- a/src/features/comment/CommentEllipsis.tsx
+++ b/src/features/comment/CommentEllipsis.tsx
@@ -37,7 +37,7 @@ import { notEmpty } from "../../helpers/array";
 import CommentEditing from "./edit/CommentEdit";
 import useCollapseRootComment from "./useCollapseRootComment";
 import { FeedContext } from "../feed/FeedContext";
-import SelectText from "../feed/SelectTextModal";
+import SelectText from "../../pages/shared/SelectTextModal";
 
 const StyledIonIcon = styled(IonIcon)`
   padding: 8px 12px;

--- a/src/features/comment/CommentEllipsis.tsx
+++ b/src/features/comment/CommentEllipsis.tsx
@@ -61,11 +61,6 @@ export default function MoreActions({ comment, rootIndex }: MoreActionsProps) {
   const [present] = useIonToast();
   const collapseRootComment = useCollapseRootComment(comment, rootIndex);
 
-  const [selectText, onDismissSelectText] = useIonModal(SelectText, {
-    text: comment.comment.content,
-    onDismiss: (data: string, role: string) => onDismissSelectText(data, role),
-  });
-
   const router = useIonRouter();
 
   const pageContext = useContext(PageContext);
@@ -88,6 +83,11 @@ export default function MoreActions({ comment, rootIndex }: MoreActionsProps) {
     item: comment,
   });
 
+  const [selectText, onDismissSelectText] = useIonModal(SelectText, {
+    text: comment.comment.content,
+    onDismiss: (data: string, role: string) => onDismissSelectText(data, role),
+  });
+
   const commentVotesById = useAppSelector(
     (state) => state.comment.commentVotesById
   );
@@ -95,8 +95,6 @@ export default function MoreActions({ comment, rootIndex }: MoreActionsProps) {
   const myVote = commentVotesById[comment.comment.id] ?? comment.my_vote;
 
   const isMyComment = getRemoteHandle(comment.creator) === myHandle;
-
-  const [selectTextModalIsOpen, setSelectTextModalIsOpen] = useState(false);
 
   return (
     <>

--- a/src/features/comment/CommentEllipsis.tsx
+++ b/src/features/comment/CommentEllipsis.tsx
@@ -15,6 +15,7 @@ import {
   pencilOutline,
   personOutline,
   shareOutline,
+  textOutline,
   trashOutline,
 } from "ionicons/icons";
 import { CommentView } from "lemmy-js-client";
@@ -36,6 +37,7 @@ import { notEmpty } from "../../helpers/array";
 import CommentEditing from "./edit/CommentEdit";
 import useCollapseRootComment from "./useCollapseRootComment";
 import { FeedContext } from "../feed/FeedContext";
+import SelectText from "../feed/SelectTextModal";
 
 const StyledIonIcon = styled(IonIcon)`
   padding: 8px 12px;
@@ -58,6 +60,11 @@ export default function MoreActions({ comment, rootIndex }: MoreActionsProps) {
   const myHandle = useAppSelector(handleSelector);
   const [present] = useIonToast();
   const collapseRootComment = useCollapseRootComment(comment, rootIndex);
+
+  const [selectText, onDismissSelectText] = useIonModal(SelectText, {
+    text: comment.comment.content,
+    onDismiss: (data: string, role: string) => onDismissSelectText(data, role),
+  });
 
   const router = useIonRouter();
 
@@ -88,6 +95,8 @@ export default function MoreActions({ comment, rootIndex }: MoreActionsProps) {
   const myVote = commentVotesById[comment.comment.id] ?? comment.my_vote;
 
   const isMyComment = getRemoteHandle(comment.creator) === myHandle;
+
+  const [selectTextModalIsOpen, setSelectTextModalIsOpen] = useState(false);
 
   return (
     <>
@@ -137,6 +146,11 @@ export default function MoreActions({ comment, rootIndex }: MoreActionsProps) {
             text: "Reply",
             role: "reply",
             icon: arrowUndoOutline,
+          },
+          {
+            text: "Select Text",
+            role: "select-text",
+            icon: textOutline,
           },
           {
             text: getHandle(comment.creator),
@@ -209,6 +223,10 @@ export default function MoreActions({ comment, rootIndex }: MoreActionsProps) {
 
               reply({ presentingElement: pageContext.page });
               break;
+            case "select-text":
+              return selectText({
+                presentingElement: pageContext.page,
+              });
             case "person":
               router.push(
                 buildGeneralBrowseLink(`/u/${getHandle(comment.creator)}`)

--- a/src/features/feed/SelectTextModal.tsx
+++ b/src/features/feed/SelectTextModal.tsx
@@ -1,18 +1,13 @@
-import { dismiss, present } from "@ionic/core/dist/types/utils/overlays";
 import {
-  IonModal,
   IonHeader,
   IonToolbar,
   IonTitle,
   IonButtons,
   IonButton,
   IonContent,
-  IonItem,
-  IonLabel,
-  IonCheckbox,
   IonPage,
 } from "@ionic/react";
-import { Dispatch, SetStateAction, useEffect, useRef, useState } from "react";
+import { useRef } from "react";
 import { Centered } from "../auth/Login";
 
 interface SelectTextProps {
@@ -42,7 +37,9 @@ export default function SelectText({ text, onDismiss }: SelectTextProps) {
         </IonToolbar>
       </IonHeader>
       <IonContent>
-        <p className="ion-padding-horizontal selectable preserve-newlines">{text}</p>
+        <p className="ion-padding-horizontal selectable preserve-newlines">
+          {text}
+        </p>
       </IonContent>
     </IonPage>
   );

--- a/src/features/feed/SelectTextModal.tsx
+++ b/src/features/feed/SelectTextModal.tsx
@@ -1,0 +1,49 @@
+import { dismiss, present } from "@ionic/core/dist/types/utils/overlays";
+import {
+  IonModal,
+  IonHeader,
+  IonToolbar,
+  IonTitle,
+  IonButtons,
+  IonButton,
+  IonContent,
+  IonItem,
+  IonLabel,
+  IonCheckbox,
+  IonPage,
+} from "@ionic/react";
+import { Dispatch, SetStateAction, useEffect, useRef, useState } from "react";
+import { Centered } from "../auth/Login";
+
+interface SelectTextProps {
+  text: string;
+  onDismiss: (data?: string | null | undefined | number, role?: string) => void;
+}
+
+export default function SelectText({ text, onDismiss }: SelectTextProps) {
+  const pageRef = useRef();
+
+  return (
+    <IonPage ref={pageRef}>
+      <IonHeader>
+        <IonToolbar>
+          <IonTitle>
+            <Centered>Select Text</Centered>
+          </IonTitle>
+          <IonButtons slot="end">
+            <IonButton
+              onClick={() => {
+                onDismiss();
+              }}
+            >
+              Dismiss
+            </IonButton>
+          </IonButtons>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent>
+        <p className="ion-padding-horizontal selectable preserve-newlines">{text}</p>
+      </IonContent>
+    </IonPage>
+  );
+}

--- a/src/features/post/shared/MoreActions.tsx
+++ b/src/features/post/shared/MoreActions.tsx
@@ -25,7 +25,7 @@ import { getHandle } from "../../../helpers/lemmy";
 import { useBuildGeneralBrowseLink } from "../../../helpers/routes";
 import CommentReply from "../../comment/reply/CommentReply";
 import { jwtSelector } from "../../auth/authSlice";
-import SelectText from "../../feed/SelectTextModal";
+import SelectText from "../../../pages/shared/SelectTextModal";
 
 interface MoreActionsProps {
   post: PostView;

--- a/src/features/post/shared/MoreActions.tsx
+++ b/src/features/post/shared/MoreActions.tsx
@@ -13,6 +13,7 @@ import {
   peopleOutline,
   personOutline,
   shareOutline,
+  textOutline,
 } from "ionicons/icons";
 import { useContext, useState } from "react";
 import { useAppDispatch, useAppSelector } from "../../../store";
@@ -24,6 +25,7 @@ import { getHandle } from "../../../helpers/lemmy";
 import { useBuildGeneralBrowseLink } from "../../../helpers/routes";
 import CommentReply from "../../comment/reply/CommentReply";
 import { jwtSelector } from "../../auth/authSlice";
+import SelectText from "../../feed/SelectTextModal";
 
 interface MoreActionsProps {
   post: PostView;
@@ -46,6 +48,11 @@ export default function MoreActions({ post, className }: MoreActionsProps) {
   const [reply, onDismissReply] = useIonModal(CommentReply, {
     onDismiss: (data: string, role: string) => onDismissReply(data, role),
     item: post,
+  });
+
+  const [selectText, onDismissSelectText] = useIonModal(SelectText, {
+    text: post.post.body,
+    onDismiss: (data: string, role: string) => onDismissSelectText(data, role),
   });
 
   const postVotesById = useAppSelector((state) => state.post.postVotesById);
@@ -99,6 +106,11 @@ export default function MoreActions({ post, className }: MoreActionsProps) {
             icon: peopleOutline,
           },
           {
+            text: "Select Text",
+            role: "select",
+            icon: textOutline,
+          },
+          {
             text: "Share",
             role: "share",
             icon: shareOutline,
@@ -149,6 +161,9 @@ export default function MoreActions({ post, className }: MoreActionsProps) {
               );
 
               break;
+            }
+            case "select": {
+              return selectText({ presentingElement: pageContext.page });
             }
             case "share": {
               navigator.share({ url: post.post.url ?? post.post.ap_id });

--- a/src/index.css
+++ b/src/index.css
@@ -49,10 +49,6 @@ ion-modal.small ion-header ion-toolbar:first-of-type {
   padding-top: 0px;
 }
 
-.preserve-newlines {
+ion-alert.preserve-newlines {
   white-space: pre-line;
-}
-
-p.selectable {
-  user-select: text;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -49,6 +49,10 @@ ion-modal.small ion-header ion-toolbar:first-of-type {
   padding-top: 0px;
 }
 
-ion-alert.preserve-newlines {
+.preserve-newlines {
   white-space: pre-line;
+}
+
+p.selectable {
+  user-select: text;
 }

--- a/src/pages/shared/SelectTextModal.tsx
+++ b/src/pages/shared/SelectTextModal.tsx
@@ -9,11 +9,18 @@ import {
 } from "@ionic/react";
 import { useRef } from "react";
 import { Centered } from "../../features/auth/Login";
+import styled from "@emotion/styled";
 
 interface SelectTextProps {
   text: string;
   onDismiss: (data?: string | null | undefined | number, role?: string) => void;
 }
+
+const SelectableText = styled.p`
+  user-select: text;
+  -webkit-user-select: text;
+  white-space: pre-wrap;
+`;
 
 export default function SelectText({ text, onDismiss }: SelectTextProps) {
   const pageRef = useRef();
@@ -37,9 +44,7 @@ export default function SelectText({ text, onDismiss }: SelectTextProps) {
         </IonToolbar>
       </IonHeader>
       <IonContent>
-        <p className="ion-padding-horizontal selectable preserve-newlines">
-          {text}
-        </p>
+        <SelectableText>{text}</SelectableText>
       </IonContent>
     </IonPage>
   );

--- a/src/pages/shared/SelectTextModal.tsx
+++ b/src/pages/shared/SelectTextModal.tsx
@@ -8,7 +8,7 @@ import {
   IonPage,
 } from "@ionic/react";
 import { useRef } from "react";
-import { Centered } from "../auth/Login";
+import { Centered } from "../../features/auth/Login";
 
 interface SelectTextProps {
   text: string;


### PR DESCRIPTION
Addresses #83 

In Apollo, there's a Select Text button in the ellipsis menu of posts and comments. This update adds similar functionality.

https://github.com/aeharding/wefwef/assets/51917118/c08df094-5d32-4332-ae6d-9b86b7a36e22

Text within this modal has been given a new `selectable` class which sets the default `user-select: none;` to `user-select: text;` to allow selecting the text. It also preserves newlines.