### PR TITLE
Fix issue #124 wrong servers when installed

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -60,7 +60,8 @@
     {
       "files": ["src/**"],
       "globals": {
-        "APP_VERSION": true
+        "APP_VERSION": true,
+        "CUSTOM_LEMMY_SERVERS": true
       }
     }
   ]

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+	"tabWidth": 2,
+	"useTabs": false,
+	"semi": true
+}

--- a/src/helpers/lemmy.ts
+++ b/src/helpers/lemmy.ts
@@ -1,8 +1,8 @@
 import { Comment, CommentView, Community } from "lemmy-js-client";
 
 export const LEMMY_SERVERS =
-  "CUSTOM_LEMMY_SERVERS" in window
-    ? (window.CUSTOM_LEMMY_SERVERS as string[])
+  typeof CUSTOM_LEMMY_SERVERS !== "undefined"
+    ? (CUSTOM_LEMMY_SERVERS as string).split(",")
     : ["lemmy.world", "lemmy.ml", "beehaw.org", "sh.itjust.works"];
 
 export interface LemmyJWT {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,3 +3,4 @@
 /// <reference types="vite-plugin-pwa/react" />
 
 declare const APP_VERSION: string;
+declare const CUSTOM_LEMMY_SERVERS: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,42 +3,48 @@ import { defineConfig } from "vitest/config";
 import { VitePWA } from "vite-plugin-pwa";
 import svgr from "vite-plugin-svgr";
 import legacy from "@vitejs/plugin-legacy";
+import { loadEnv } from "vite";
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [
-    react({
-      jsxImportSource: "@emotion/react",
-      babel: {
-        plugins: ["@emotion/babel-plugin"],
-      },
-    }),
-    svgr(),
-    VitePWA({ registerType: "prompt" }),
-    legacy({
-      modernPolyfills: ["es.array.at"],
-    }),
-  ],
-  // TODO: Outdated clients trying to access stale codesplit js chucks
-  // break. This breaks iOS transitions.
-  // Put everything into one chunk for now.
-  build: {
-    rollupOptions: {
-      output: {
-        manualChunks: () => "index.js",
+export default ({ mode }) => {
+  process.env = { ...process.env, ...loadEnv(mode, process.cwd(), "") };
+
+  return defineConfig({
+    plugins: [
+      react({
+        jsxImportSource: "@emotion/react",
+        babel: {
+          plugins: ["@emotion/babel-plugin"],
+        },
+      }),
+      svgr(),
+      VitePWA({ registerType: "prompt" }),
+      legacy({
+        modernPolyfills: ["es.array.at"],
+      }),
+    ],
+    // TODO: Outdated clients trying to access stale codesplit js chucks
+    // break. This breaks iOS transitions.
+    // Put everything into one chunk for now.
+    build: {
+      rollupOptions: {
+        output: {
+          manualChunks: () => "index.js",
+        },
       },
     },
-  },
-  define: {
-    // eslint-disable-next-line no-undef
-    APP_VERSION: JSON.stringify(process.env.npm_package_version),
-  },
-  test: {
-    globals: true,
-    environment: "jsdom",
-    setupFiles: "./src/setupTests.ts",
-  },
-  optimizeDeps: {
-    exclude: ["mdast-util-gfm-autolink-literal-lemmy"],
-  },
-});
+    define: {
+      // eslint-disable-next-line no-undef
+      APP_VERSION: JSON.stringify(process.env.npm_package_version),
+      CUSTOM_LEMMY_SERVERS: JSON.stringify(process.env.CUSTOM_LEMMY_SERVERS),
+    },
+    test: {
+      globals: true,
+      environment: "jsdom",
+      setupFiles: "./src/setupTests.ts",
+    },
+    optimizeDeps: {
+      exclude: ["mdast-util-gfm-autolink-literal-lemmy"],
+    },
+  });
+};


### PR DESCRIPTION
Fixes Issue #124 

Defines the `CUSTOM_LEMMY_SERVERS` as a variable through `vite.config.ts`, allowing it to be present after PWA installation.

This requires reading the the environment via Vite's `loadEnv` function, and define the config using a function in order to be able to read the current `mode` (`development`, `production`, `test`).

The `CUSTOM_LEMMY_SERVERS` can be defined in the environment either system wide or through a `.env` file such as `.env.production.local` or `.env.development.local` (the `.local` is not strictly needed, but `.local` files are gitignored).

Sidenote: I added a `.prettierrc` because I use different settings and they were wreaking havoc on the code, this way it should be consistent.