### PR TITLE
feat: Let self-hosted instances have a server whitelist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,5 +49,7 @@ COPY --from=builder /wefwef/dist ./dist
 EXPOSE 5314/tcp
 
 ENV PORT=5314
+ENV CUSTOM_LEMMY_SERVERS=
+ENV ALLOWED_LEMMY_SERVERS=
 
 CMD ["node", "./server.mjs"]


### PR DESCRIPTION
I wanted to be able to only allow certain servers to be proxied. I was also having trouble setting the environment variables without the two `ENV` lines in the Dockerfile, so those lines are for that.

I'm open to further changes, if this is not satisfactory for being upstreamed. Thanks!