### PR TITLE
Fix maximum files size for uploads

### DIFF
--- a/src/services/lemmy.ts
+++ b/src/services/lemmy.ts
@@ -27,10 +27,10 @@ const PICTRS_URL = "/pictrs/image";
 export async function uploadImage(url: string, auth: string, image: File) {
   const compressedImageIfNeeded = await reduceFileSize(
     image,
-    1_500_000,
+    990_000, // 990 kB - Lemmy's default limit is 1MB
     1500,
     1500,
-    0.9
+    0.85
   );
 
   const formData = new FormData();


### PR DESCRIPTION
1MB is Lemmy's default photo size max https://github.com/LemmyNet/lemmy-ui/issues/1532