### PR TITLE
Refactor/improve login modal performance

### DIFF
--- a/src/features/comment/CommentEllipsis.tsx
+++ b/src/features/comment/CommentEllipsis.tsx
@@ -24,7 +24,6 @@ import { useBuildGeneralBrowseLink } from "../../helpers/routes";
 import { useAppDispatch, useAppSelector } from "../../store";
 import { handleSelector, jwtSelector } from "../auth/authSlice";
 import { PageContext } from "../auth/PageContext";
-import Login from "../auth/Login";
 import CommentReply from "./reply/CommentReply";
 import {
   getHandle,
@@ -38,6 +37,7 @@ import CommentEditing from "./edit/CommentEdit";
 import useCollapseRootComment from "./useCollapseRootComment";
 import { FeedContext } from "../feed/FeedContext";
 import SelectText from "../../pages/shared/SelectTextModal";
+import { ModalContext } from "../../pages/shared/ModalContext";
 
 const StyledIonIcon = styled(IonIcon)`
   padding: 8px 12px;
@@ -64,9 +64,7 @@ export default function MoreActions({ comment, rootIndex }: MoreActionsProps) {
   const router = useIonRouter();
 
   const pageContext = useContext(PageContext);
-  const [login, onDismiss] = useIonModal(Login, {
-    onDismiss: (data: string, role: string) => onDismiss(data, role),
-  });
+  const { login } = useContext(ModalContext);
 
   const [reply, onDismissReply] = useIonModal(CommentReply, {
     onDismiss: (data: string, role: string) => {
@@ -105,7 +103,6 @@ export default function MoreActions({ comment, rootIndex }: MoreActionsProps) {
           e.stopPropagation();
         }}
       />
-
       <IonActionSheet
         cssClass="left-align-buttons"
         onClick={(e) => e.stopPropagation()}

--- a/src/features/comment/Comments.tsx
+++ b/src/features/comment/Comments.tsx
@@ -8,6 +8,7 @@ import {
   IonRefresher,
   IonRefresherContent,
   IonSpinner,
+  useIonModal,
   useIonToast,
 } from "@ionic/react";
 import styled from "@emotion/styled";
@@ -24,6 +25,8 @@ import { useSetActivePage } from "../auth/AppContext";
 import { FeedContext } from "../feed/FeedContext";
 import { jwtSelector } from "../auth/authSlice";
 import { defaultCommentDepthSelector } from "../settings/appearance/appearanceSlice";
+import Login from "../auth/Login";
+import { ModalContext } from "../../pages/shared/ModalContext";
 
 const centerCss = css`
   position: relative;
@@ -217,33 +220,39 @@ export default function Comments({
     ));
   }, [commentTree, comments.length, highlightedCommentId, loading, op]);
 
+  const [login, onDismissLogin] = useIonModal(Login, {
+    onDismiss: (data: string, role: string) => onDismissLogin(data, role),
+  });
+
   return (
     <FeedContext.Provider
       value={{ refresh: () => fetchComments(true), appendComments }}
     >
-      <IonRefresher
-        slot="fixed"
-        onIonRefresh={handleRefresh}
-        disabled={!isListAtTop}
-      >
-        <IonRefresherContent />
-      </IonRefresher>
-      <Virtuoso
-        ref={virtuosoRef}
-        style={{ height: "100%" }}
-        totalCount={allComments.length + 1}
-        itemContent={(index) => (index ? allComments[index - 1] : header)}
-        endReached={() => fetchComments()}
-        atTopStateChange={setIsListAtTop}
-        components={
-          typeof commentId === "number"
-            ? {
-                // add space for the <ViewAllComments /> fixed component
-                Footer: () => <div style={{ height: "70px" }} />,
-              }
-            : {}
-        }
-      />
+      <ModalContext.Provider value={{ login }}>
+        <IonRefresher
+          slot="fixed"
+          onIonRefresh={handleRefresh}
+          disabled={!isListAtTop}
+        >
+          <IonRefresherContent />
+        </IonRefresher>
+        <Virtuoso
+          ref={virtuosoRef}
+          style={{ height: "100%" }}
+          totalCount={allComments.length + 1}
+          itemContent={(index) => (index ? allComments[index - 1] : header)}
+          endReached={() => fetchComments()}
+          atTopStateChange={setIsListAtTop}
+          components={
+            typeof commentId === "number"
+              ? {
+                  // add space for the <ViewAllComments /> fixed component
+                  Footer: () => <div style={{ height: "70px" }} />,
+                }
+              : {}
+          }
+        />
+      </ModalContext.Provider>
     </FeedContext.Provider>
   );
 }

--- a/src/features/community/MoreActions.tsx
+++ b/src/features/community/MoreActions.tsx
@@ -2,7 +2,6 @@ import {
   IonActionSheet,
   IonButton,
   IonIcon,
-  useIonModal,
   useIonRouter,
   useIonToast,
 } from "@ionic/react";
@@ -17,11 +16,11 @@ import { useContext, useMemo, useState } from "react";
 import { useAppDispatch, useAppSelector } from "../../store";
 import { followCommunity } from "./communitySlice";
 import { PageContext } from "../auth/PageContext";
-import Login from "../auth/Login";
 import { isAdminSelector, jwtSelector } from "../auth/authSlice";
 import { NewPostContext } from "../post/new/NewPostModal";
 import { useBuildGeneralBrowseLink } from "../../helpers/routes";
 import { checkIsMod } from "../../helpers/lemmy";
+import { ModalContext } from "../../pages/shared/ModalContext";
 
 interface MoreActionsProps {
   community: string;
@@ -38,9 +37,7 @@ export default function MoreActions({ community }: MoreActionsProps) {
   const isAdmin = useAppSelector(isAdminSelector);
 
   const pageContext = useContext(PageContext);
-  const [login, onDismissLogin] = useIonModal(Login, {
-    onDismiss: (data: string, role: string) => onDismissLogin(data, role),
-  });
+  const { login } = useContext(ModalContext);
 
   const communityByHandle = useAppSelector(
     (state) => state.community.communityByHandle

--- a/src/features/feed/PostCommentFeed.tsx
+++ b/src/features/feed/PostCommentFeed.tsx
@@ -8,6 +8,9 @@ import { receivedPosts } from "../post/postSlice";
 import { receivedComments } from "../comment/commentSlice";
 import Post from "../post/inFeed/Post";
 import CommentHr from "../comment/CommentHr";
+import { useIonModal } from "@ionic/react";
+import Login from "../auth/Login";
+import { ModalContext } from "../../pages/shared/ModalContext";
 
 const thickBorderCss = css`
   border-bottom: 8px solid var(--thick-separator-color);
@@ -86,7 +89,13 @@ export default function PostCommentFeed({
     [_fetchFn, dispatch]
   );
 
+  const [login, onDismissLogin] = useIonModal(Login, {
+    onDismiss: (data: string, role: string) => onDismissLogin(data, role),
+  });
+
   return (
-    <Feed fetchFn={fetchFn} renderItemContent={renderItemContent} {...rest} />
+    <ModalContext.Provider value={{ login }}>
+      <Feed fetchFn={fetchFn} renderItemContent={renderItemContent} {...rest} />
+    </ModalContext.Provider>
   );
 }

--- a/src/features/labels/Vote.tsx
+++ b/src/features/labels/Vote.tsx
@@ -9,6 +9,7 @@ import { PageContext } from "../auth/PageContext";
 import { voteOnComment } from "../comment/commentSlice";
 import { voteError } from "../../helpers/toastMessages";
 import { jwtSelector } from "../auth/authSlice";
+import { ModalContext } from "../../pages/shared/ModalContext";
 
 const Container = styled.div<{ vote: 1 | -1 | 0 | undefined }>`
   display: flex;
@@ -54,9 +55,7 @@ export default function Vote({
   const score = existingScore - (voteFromServer ?? 0) + (votesById[id] ?? 0);
 
   const jwt = useAppSelector(jwtSelector);
-  const [login, onDismiss] = useIonModal(Login, {
-    onDismiss: (data: string, role: string) => onDismiss(data, role),
-  });
+  const { login } = useContext(ModalContext);
   const pageContext = useContext(PageContext);
 
   return (

--- a/src/features/labels/Vote.tsx
+++ b/src/features/labels/Vote.tsx
@@ -1,9 +1,8 @@
 import { useAppDispatch, useAppSelector } from "../../store";
-import { IonIcon, useIonModal, useIonToast } from "@ionic/react";
+import { IonIcon, useIonToast } from "@ionic/react";
 import { arrowDownSharp, arrowUpSharp } from "ionicons/icons";
 import styled from "@emotion/styled";
 import { voteOnPost } from "../post/postSlice";
-import Login from "../auth/Login";
 import { useContext } from "react";
 import { PageContext } from "../auth/PageContext";
 import { voteOnComment } from "../comment/commentSlice";

--- a/src/features/post/shared/MoreActions.tsx
+++ b/src/features/post/shared/MoreActions.tsx
@@ -18,7 +18,6 @@ import {
 import { useContext, useState } from "react";
 import { useAppDispatch, useAppSelector } from "../../../store";
 import { PageContext } from "../../auth/PageContext";
-import Login from "../../auth/Login";
 import { PostView } from "lemmy-js-client";
 import { voteOnPost } from "../postSlice";
 import { getHandle } from "../../../helpers/lemmy";
@@ -28,6 +27,7 @@ import { jwtSelector } from "../../auth/authSlice";
 import SelectText from "../../../pages/shared/SelectTextModal";
 import { ActionButton } from "../actions/ActionButton";
 import { css } from "@emotion/react";
+import { ModalContext } from "../../../pages/shared/ModalContext";
 
 interface MoreActionsProps {
   post: PostView;
@@ -43,9 +43,7 @@ export default function MoreActions({ post, className }: MoreActionsProps) {
   const router = useIonRouter();
 
   const pageContext = useContext(PageContext);
-  const [login, onDismiss] = useIonModal(Login, {
-    onDismiss: (data: string, role: string) => onDismiss(data, role),
-  });
+  const { login } = useContext(ModalContext);
 
   const [reply, onDismissReply] = useIonModal(CommentReply, {
     onDismiss: (data: string, role: string) => onDismissReply(data, role),

--- a/src/features/post/shared/VoteButton.tsx
+++ b/src/features/post/shared/VoteButton.tsx
@@ -1,6 +1,5 @@
 import styled from "@emotion/styled";
-import { IonIcon, useIonModal, useIonToast } from "@ionic/react";
-import Login from "../../auth/Login";
+import { IonIcon, useIonToast } from "@ionic/react";
 import { useContext } from "react";
 import { PageContext } from "../../auth/PageContext";
 import { useAppDispatch, useAppSelector } from "../../../store";
@@ -10,6 +9,7 @@ import { arrowDownSharp, arrowUpSharp } from "ionicons/icons";
 import { ActionButton } from "../actions/ActionButton";
 import { voteError } from "../../../helpers/toastMessages";
 import { jwtSelector } from "../../auth/authSlice";
+import { ModalContext } from "../../../pages/shared/ModalContext";
 
 export const Item = styled(ActionButton, {
   shouldForwardProp: (prop) => prop !== "on" && prop !== "activeColor",
@@ -35,9 +35,7 @@ export function VoteButton({ type, postId }: VoteButtonProps) {
   const [present] = useIonToast();
   const dispatch = useAppDispatch();
   const pageContext = useContext(PageContext);
-  const [login, onDismiss] = useIonModal(Login, {
-    onDismiss: (data: string, role: string) => onDismiss(data, role),
-  });
+  const { login } = useContext(ModalContext);
   const jwt = useAppSelector(jwtSelector);
 
   const postVotesById = useAppSelector((state) => state.post.postVotesById);

--- a/src/features/shared/sliding/BaseSlidingVote.tsx
+++ b/src/features/shared/sliding/BaseSlidingVote.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import { IonIcon, useIonModal, useIonToast } from "@ionic/react";
+import { IonIcon, useIonToast } from "@ionic/react";
 import { arrowDownSharp, arrowUpSharp } from "ionicons/icons";
 import React, { useCallback, useContext, useMemo } from "react";
 import SlidingItem, {
@@ -15,7 +15,6 @@ import {
 } from "lemmy-js-client";
 import { PageContext } from "../../auth/PageContext";
 import { useAppDispatch, useAppSelector } from "../../../store";
-import Login from "../../auth/Login";
 import { voteOnPost } from "../../post/postSlice";
 import { voteError } from "../../../helpers/toastMessages";
 import { voteOnComment } from "../../comment/commentSlice";

--- a/src/features/shared/sliding/BaseSlidingVote.tsx
+++ b/src/features/shared/sliding/BaseSlidingVote.tsx
@@ -20,6 +20,7 @@ import { voteOnPost } from "../../post/postSlice";
 import { voteError } from "../../../helpers/toastMessages";
 import { voteOnComment } from "../../comment/commentSlice";
 import { jwtSelector } from "../../auth/authSlice";
+import { ModalContext } from "../../../pages/shared/ModalContext";
 
 const VoteArrow = styled(IonIcon)<{
   slash: boolean;
@@ -71,9 +72,7 @@ export default function BaseSlidingVote({
     ? postVotesById[item.post.id] ?? typedMyVote
     : commentVotesById[item.comment.id] ?? typedMyVote;
 
-  const [login, onDismiss] = useIonModal(Login, {
-    onDismiss: (data: string, role: string) => onDismiss(data, role),
-  });
+  const { login } = useContext(ModalContext);
 
   const onVote = useCallback(
     async (score: 1 | -1 | 0) => {

--- a/src/features/shared/sliding/SlidingNestedCommentVote.tsx
+++ b/src/features/shared/sliding/SlidingNestedCommentVote.tsx
@@ -9,8 +9,8 @@ import { FeedContext } from "../../feed/FeedContext";
 import BaseSlidingVote from "./BaseSlidingVote";
 import { useAppSelector } from "../../../store";
 import { jwtSelector } from "../../auth/authSlice";
-import Login from "../../auth/Login";
 import useCollapseRootComment from "../../comment/useCollapseRootComment";
+import { ModalContext } from "../../../pages/shared/ModalContext";
 
 interface SlidingVoteProps {
   children: React.ReactNode;
@@ -29,12 +29,9 @@ export default function SlidingNestedCommentVote({
 }: SlidingVoteProps) {
   const { refresh: refreshPost } = useContext(FeedContext);
   const pageContext = useContext(PageContext);
+  const { login } = useContext(ModalContext);
   const jwt = useAppSelector(jwtSelector);
   const collapseRootComment = useCollapseRootComment(item, rootIndex);
-
-  const [login, onDismissLogin] = useIonModal(Login, {
-    onDismiss: (data: string, role: string) => onDismissLogin(data, role),
-  });
 
   const [reply, onDismissReply] = useIonModal(CommentReply, {
     onDismiss: (data: string, role: string) => {

--- a/src/features/shared/sliding/SlidingPostVote.tsx
+++ b/src/features/shared/sliding/SlidingPostVote.tsx
@@ -9,7 +9,7 @@ import { FeedContext } from "../../feed/FeedContext";
 import BaseSlidingVote from "./BaseSlidingVote";
 import { useAppSelector } from "../../../store";
 import { jwtSelector } from "../../auth/authSlice";
-import Login from "../../auth/Login";
+import { ModalContext } from "../../../pages/shared/ModalContext";
 
 interface SlidingVoteProps {
   children: React.ReactNode;
@@ -24,11 +24,8 @@ export default function SlidingVote({
 }: SlidingVoteProps) {
   const { refresh: refreshPost } = useContext(FeedContext);
   const pageContext = useContext(PageContext);
+  const { login } = useContext(ModalContext);
   const jwt = useAppSelector(jwtSelector);
-
-  const [login, onDismissLogin] = useIonModal(Login, {
-    onDismiss: (data: string, role: string) => onDismissLogin(data, role),
-  });
 
   const [reply, onDismissReply] = useIonModal(CommentReply, {
     onDismiss: (data: string, role: string) => {

--- a/src/pages/shared/CommunityPage.tsx
+++ b/src/pages/shared/CommunityPage.tsx
@@ -5,6 +5,7 @@ import {
   IonPage,
   IonTitle,
   IonToolbar,
+  useIonModal,
 } from "@ionic/react";
 import { FetchFn } from "../../features/feed/Feed";
 import { Redirect, useParams } from "react-router";
@@ -22,6 +23,8 @@ import PostCommentFeed, {
 } from "../../features/feed/PostCommentFeed";
 import { jwtSelector } from "../../features/auth/authSlice";
 import { NewPostContextProvider } from "../../features/post/new/NewPostModal";
+import { ModalContext } from "./ModalContext";
+import Login from "../../features/auth/Login";
 
 export default function CommunityPage() {
   const buildGeneralBrowseLink = useBuildGeneralBrowseLink();
@@ -60,6 +63,10 @@ export default function CommunityPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [community]);
 
+  const [login, onDismissLogin] = useIonModal(Login, {
+    onDismiss: (data: string, role: string) => onDismissLogin(data, role),
+  });
+
   if (community.includes("@") && community.split("@")[1] === actor)
     return (
       <Redirect
@@ -70,28 +77,30 @@ export default function CommunityPage() {
 
   return (
     <NewPostContextProvider community={community}>
-      <IonPage>
-        <IonHeader>
-          <IonToolbar>
-            <IonButtons slot="start">
-              <AppBackButton
-                defaultText="Communities"
-                defaultHref={buildGeneralBrowseLink("/")}
-              />
-            </IonButtons>
+      <ModalContext.Provider value={{ login }}>
+        <IonPage>
+          <IonHeader>
+            <IonToolbar>
+              <IonButtons slot="start">
+                <AppBackButton
+                  defaultText="Communities"
+                  defaultHref={buildGeneralBrowseLink("/")}
+                />
+              </IonButtons>
 
-            <IonTitle>{community}</IonTitle>
+              <IonTitle>{community}</IonTitle>
 
-            <IonButtons slot="end">
-              <PostSort />
-              <MoreActions community={community} />
-            </IonButtons>
-          </IonToolbar>
-        </IonHeader>
-        <IonContent>
-          <PostCommentFeed fetchFn={fetchFn} communityName={community} />
-        </IonContent>
-      </IonPage>
+              <IonButtons slot="end">
+                <PostSort />
+                <MoreActions community={community} />
+              </IonButtons>
+            </IonToolbar>
+          </IonHeader>
+          <IonContent>
+            <PostCommentFeed fetchFn={fetchFn} communityName={community} />
+          </IonContent>
+        </IonPage>
+      </ModalContext.Provider>
     </NewPostContextProvider>
   );
 }

--- a/src/pages/shared/ModalContext.ts
+++ b/src/pages/shared/ModalContext.ts
@@ -1,0 +1,16 @@
+import { createContext } from "react";
+import type { ModalOptions } from "@ionic/core/components";
+import { HookOverlayOptions } from "@ionic/react/dist/types/hooks/HookOverlayOptions";
+
+type ModalHandler = (
+  options?: Omit<ModalOptions, "component" | "componentProps"> &
+    HookOverlayOptions
+) => void;
+
+interface ModalContext {
+  login: ModalHandler;
+}
+// todo
+export const ModalContext = createContext<ModalContext>({
+  login: () => {},
+}); // the login modal needs to be (almost?) everywhere, so it is easier to simply provide it from the App level


### PR DESCRIPTION
This is quite a weird (and maybe pointless) PR.

The problem: some performed actions (opening the modals, for example) are quite stutter-ish on mobile (iPhone 13 Pro Max with iOS 16.5.1) which is annoying and ugly to see.

Looking through the code I saw that many modals are rendered within the post component (and subcomponents!), although they are the same for every post, so I moved (for this PR, which is a proof-of-concept more than anything) the hook to call the Login Modal up to the parent (so in the PostFeed component) and I passed down the Childs the login function. 

This is dirty-ish too in my opinion, and probably it would be best provided by a LoginModal context instead of prop drilling


[A video with before vs after ](https://imgur.com/a/2CIZDo4)