### PR TITLE
Pass along X-Forwarded-* headers

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -101,6 +101,7 @@ app.use(
     router: (req) => `https://${req.params.actor}`,
     changeOrigin: true,
     secure: true,
+    xfwd: true,
     pathRewrite: (path) => path.split("/").slice(3).join("/"),
     onProxyReq: (clientReq, req) => {
       clientReq.setHeader(


### PR DESCRIPTION
These headers help the origin web server identify the original IP that the request came from.
Otherwise, the requests will all appear to come from the wefwef server, which can be problematic for moderation and rate-limiting.

Refs:
* https://github.com/http-party/node-http-proxy#options
* https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For