### PR TITLE
Move toast above tab bar

### DIFF
--- a/src/GlobalStyles.tsx
+++ b/src/GlobalStyles.tsx
@@ -44,6 +44,10 @@ export default function GlobalStyles({ children }: GlobalStylesProps) {
             }
           }
 
+          ion-toast {
+            transform: translateY(-6.9ex);
+          }
+
           ${baseVariables}
 
           ${isDark ? darkVariables : lightVariables}


### PR DESCRIPTION
This is currently a draft just to show a simple change that seems to at least improve the toast situation. I am also looking for feedback on if there is possibly a better way to do this.

Because of the hard coded offset some testing on various devices would be useful. This fixes #147, but not the extra feature of being able to swipe to dismiss.