### PR TITLE
feat(search-page): focus search input on search tab click

### DIFF
--- a/src/TabbedRoutes.tsx
+++ b/src/TabbedRoutes.tsx
@@ -75,6 +75,7 @@ export default function TabbedRoutes() {
     (shouldInstall ? 1 : 0) + (updateStatus === "outdated" ? 1 : 0);
 
   const pageRef = useRef<IonRouterOutletCustomEvent<unknown>["target"]>(null);
+  const searchInput = useRef<HTMLIonSearchbarElement>(null);
 
   const connectedInstance = useAppSelector(
     (state) => state.auth.connectedInstance
@@ -128,6 +129,11 @@ export default function TabbedRoutes() {
     if (!isSearchButtonDisabled) return;
 
     if (await scrollUpIfNeeded()) return;
+
+    if (location.pathname === "/search" && searchInput.current) {
+      searchInput.current.setFocus();
+      return;
+    }
 
     router.push(`/search`, "back");
   }
@@ -297,7 +303,7 @@ export default function TabbedRoutes() {
           </Route>
 
           <Route exact path="/search">
-            <SearchPage />
+            <SearchPage ref={searchInput} />
           </Route>
           <Route exact path="/search/posts/:search">
             <SearchPostsResultsPage type="Posts" />

--- a/src/pages/search/SearchPage.tsx
+++ b/src/pages/search/SearchPage.tsx
@@ -1,33 +1,47 @@
+import { type ComponentRef } from "@ionic/core";
 import { IonHeader, IonPage, IonSearchbar, IonToolbar } from "@ionic/react";
 import AppContent from "../../features/shared/AppContent";
-import { useState } from "react";
+import { forwardRef, useState } from "react";
 import { css } from "@emotion/react";
 import TrendingCommunities from "../../features/search/TrendingCommunities";
 import SearchOptions from "../../features/search/SearchOptions";
 
-export default function SearchPage() {
-  const [search, setSearch] = useState("");
+type SearchPageProps = {
+  ref?: ComponentRef;
+};
 
-  return (
-    <IonPage className="grey-bg">
-      <IonHeader>
-        <IonToolbar>
-          <IonSearchbar
-            placeholder="Search posts, communities, users"
-            showCancelButton={search ? "always" : "never"}
-            showClearButton="never"
-            css={css`
-              padding-top: 0 !important;
-              padding-bottom: 0 !important;
-            `}
-            value={search}
-            onIonInput={(e) => setSearch(e.detail.value ?? "")}
-          />
-        </IonToolbar>
-      </IonHeader>
-      <AppContent scrollY={!search}>
-        {!search ? <TrendingCommunities /> : <SearchOptions search={search} />}
-      </AppContent>
-    </IonPage>
-  );
-}
+const SearchPage = forwardRef<HTMLIonSearchbarElement, SearchPageProps>(
+  function SearchPage(_props, forwardedRef) {
+    const [search, setSearch] = useState("");
+
+    return (
+      <IonPage className="grey-bg">
+        <IonHeader>
+          <IonToolbar>
+            <IonSearchbar
+              ref={forwardedRef}
+              placeholder="Search posts, communities, users"
+              showCancelButton={search ? "always" : "never"}
+              showClearButton="never"
+              css={css`
+                padding-top: 0 !important;
+                padding-bottom: 0 !important;
+              `}
+              value={search}
+              onIonInput={(e) => setSearch(e.detail.value ?? "")}
+            />
+          </IonToolbar>
+        </IonHeader>
+        <AppContent scrollY={!search}>
+          {!search ? (
+            <TrendingCommunities />
+          ) : (
+            <SearchOptions search={search} />
+          )}
+        </AppContent>
+      </IonPage>
+    );
+  }
+);
+
+export default SearchPage;


### PR DESCRIPTION
I wanted to restore a pattern from Apollo my muscle memory has been trying to use in wefwef: When the search page is shown and you click the search tab again, the input at the top is focused.

I haven't worked with Ionic before and they don't seem to provide any documentation on how to use their project with Typescript, so I did what I could but let me know if something should be changed. Specifically it seems like you shouldn't import their types, which they add to the global namespace instead, but does this work with the linter?