### PR TITLE
Change how search bar is cleared

### DIFF
--- a/src/pages/search/SearchPage.tsx
+++ b/src/pages/search/SearchPage.tsx
@@ -23,8 +23,8 @@ export default function SearchPage() {
           <IonSearchbar
             ref={searchBarRef}
             placeholder="Search posts, communities, users"
-            showCancelButton={search ? "always" : "never"}
-            showClearButton="never"
+            showCancelButton={search ? "always" : "focus"}
+            showClearButton={search ? "always" : "never"}
             css={css`
               padding-top: 0 !important;
               padding-bottom: 0 !important;


### PR DESCRIPTION
Add clear button to search bar so you can quickly clear text without loosing focus of the search bar. Also change cancel button to be shown when there is some text on the search bar or if the search bar is focused.