### PR TITLE
Move settings to Dexie

### DIFF
--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -24,12 +24,8 @@ export type CommentThreadCollapse =
   (typeof OCommentThreadCollapse)[keyof typeof OCommentThreadCollapse];
 
 export type SettingValueTypes = {
-  font_size_multiplier: number;
-  use_system_font_size: boolean;
   collapse_comment_threads: CommentThreadCollapse;
   post_appearance_type: PostAppearanceType;
-  use_system_dark_mode: boolean;
-  user_dark_mode: boolean;
   blur_nsfw: boolean;
 };
 
@@ -42,18 +38,6 @@ export interface ISettingItem<T extends keyof SettingValueTypes> {
 
 const defaultSettings: ISettingItem<keyof SettingValueTypes>[] = [
   {
-    key: "font_size_multiplier",
-    value: 1,
-    user_handle: "",
-    community: "",
-  },
-  {
-    key: "use_system_font_size",
-    value: false,
-    user_handle: "",
-    community: "",
-  },
-  {
     key: "collapse_comment_threads",
     value: OCommentThreadCollapse.Never,
     user_handle: "",
@@ -62,18 +46,6 @@ const defaultSettings: ISettingItem<keyof SettingValueTypes>[] = [
   {
     key: "post_appearance_type",
     value: OPostAppearanceType.Large,
-    user_handle: "",
-    community: "",
-  },
-  {
-    key: "use_system_dark_mode",
-    value: true,
-    user_handle: "",
-    community: "",
-  },
-  {
-    key: "user_dark_mode",
-    value: false,
     user_handle: "",
     community: "",
   },
@@ -236,12 +208,8 @@ export class WefwefDB extends Dexie {
 
   private async migrateFromLocalStorageSettings(tx: Transaction) {
     const localStorageMigrationKeys = {
-      font_size_multiplier: "appearance--font-size-multiplier",
-      use_system_font_size: "appearance--font-use-system",
       collapse_comment_threads: "appearance--collapse-comment-threads",
       post_appearance_type: "appearance--post-type",
-      use_system_dark_mode: "appearance--dark-use-system",
-      user_dark_mode: "appearance--dark-user-mode",
     };
 
     const settingsTable = tx.table("settings");

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -290,19 +290,12 @@ export class WefwefDB extends Dexie {
         throw new Error(`Setting ${key} not found`);
       }
 
-      if (!setting && community !== "") {
-        // Fall back to user settings if no specific setting for the community is found
-        setting = await this.findSetting(key, user_handle, "");
-      }
-
-      if (!setting && user_handle !== "") {
-        // Fall back to community settings if no specific setting for the user is found
-        setting = await this.findSetting(key, "", community);
-      }
-
-      if (!setting) {
-        // Fall back to global settings if no specific setting for the user is found
-        setting = await this.findSetting(key, "", "");
+      if (!setting && user_handle !== "" && community !== "") {
+        // Try to find the setting with user_handle only, community only and no specificity
+        setting =
+          (await this.findSetting(key, user_handle, "")) ||
+          (await this.findSetting(key, "", community)) ||
+          (await this.findSetting(key, "", ""));
       }
 
       if (!setting) {

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -1,4 +1,4 @@
-import Dexie, { Table } from "dexie";
+import Dexie, { Table, Transaction } from "dexie";
 
 export interface IPostMetadata {
   post_id: number;
@@ -7,25 +7,109 @@ export interface IPostMetadata {
   hidden_updated_at?: number;
 }
 
+export const OPostAppearanceType = {
+  Compact: "compact",
+  Large: "large",
+} as const;
+
+export type PostAppearanceType =
+  (typeof OPostAppearanceType)[keyof typeof OPostAppearanceType];
+
+export const OCommentThreadCollapse = {
+  Always: "always",
+  Never: "never",
+} as const;
+
+export type CommentThreadCollapse =
+  (typeof OCommentThreadCollapse)[keyof typeof OCommentThreadCollapse];
+
+export type SettingValueTypes = {
+  font_size_multiplier: number;
+  use_system_font_size: boolean;
+  collapse_comment_threads: CommentThreadCollapse;
+  post_appearance_type: PostAppearanceType;
+  use_system_dark_mode: boolean;
+  user_dark_mode: boolean;
+  blur_nsfw: boolean;
+};
+
+export interface ISettingItem<T extends keyof SettingValueTypes> {
+  key: T;
+  value: SettingValueTypes[T];
+  user_handle: string;
+  community: string;
+}
+
+const defaultSettings: ISettingItem<keyof SettingValueTypes>[] = [
+  {
+    key: "font_size_multiplier",
+    value: 1,
+    user_handle: "",
+    community: "",
+  },
+  {
+    key: "use_system_font_size",
+    value: false,
+    user_handle: "",
+    community: "",
+  },
+  {
+    key: "collapse_comment_threads",
+    value: OCommentThreadCollapse.Never,
+    user_handle: "",
+    community: "",
+  },
+  {
+    key: "post_appearance_type",
+    value: OPostAppearanceType.Large,
+    user_handle: "",
+    community: "",
+  },
+  {
+    key: "use_system_dark_mode",
+    value: true,
+    user_handle: "",
+    community: "",
+  },
+  {
+    key: "user_dark_mode",
+    value: false,
+    user_handle: "",
+    community: "",
+  },
+  {
+    key: "blur_nsfw",
+    value: true,
+    user_handle: "",
+    community: "",
+  },
+];
+
 export const CompoundKeys = {
   postMetadata: {
     post_id_and_user_handle: "[post_id+user_handle]",
     user_handle_and_hidden: "[user_handle+hidden]",
   },
+  settings: {
+    key_and_user_handle_and_community: "[key+user_handle+community]",
+  },
 };
 
 export class WefwefDB extends Dexie {
   postMetadatas!: Table<IPostMetadata, number>;
+  settings!: Table<ISettingItem<keyof SettingValueTypes>, string>;
 
   constructor() {
     super("WefwefDB");
 
-    /* IMPORTANT: Do not alter the version. If you want to change the schema,
-       create a higher version and provide migration logic.
+    /* IMPORTANT: Do not alter the version if you're changing an existing schema.
+       If you want to change the schema, create a higher version and provide migration logic.
        Always assume there is a device out there with the first version of the app.
+       Also please read the Dexie documentation about versioning.
     */
-    this.version(1).stores({
-      postMetadatas: `
+    this.version(2)
+      .stores({
+        postMetadatas: `
         ++,
         ${CompoundKeys.postMetadata.post_id_and_user_handle},
         ${CompoundKeys.postMetadata.user_handle_and_hidden},
@@ -34,9 +118,31 @@ export class WefwefDB extends Dexie {
         hidden,
         hidden_updated_at
       `,
+        settings: `
+        ++,
+        key,
+        ${CompoundKeys.settings.key_and_user_handle_and_community},
+        value,
+        user_handle,
+        community
+      `,
+      })
+      .upgrade(async (tx) => {
+        await this.populateDefaultSettings(tx);
+        await this.migrateFromLocalStorageSettings(tx);
+      });
+
+    this.on("populate", async () => {
+      this.transaction("rw", this.settings, async (tx) => {
+        await this.populateDefaultSettings(tx);
+        await this.migrateFromLocalStorageSettings(tx);
+      });
     });
   }
 
+  /*
+   * Post Metadata
+   */
   async getPostMetadatas(post_id: number | number[], user_handle: string) {
     const post_ids = Array.isArray(post_id) ? post_id : [post_id];
 
@@ -117,6 +223,99 @@ export class WefwefDB extends Dexie {
       .filter(filterFn)
       .limit(limit)
       .toArray();
+  }
+
+  /*
+   * Settings
+   */
+
+  async populateDefaultSettings(tx: Transaction) {
+    const settingsTable = tx.table("settings");
+    settingsTable.bulkAdd(defaultSettings);
+  }
+
+  async migrateFromLocalStorageSettings(tx: Transaction) {
+    const localStorageMigrationKeys = {
+      font_size_multiplier: "appearance--font-size-multiplier",
+      use_system_font_size: "appearance--font-use-system",
+      collapse_comment_threads: "appearance--collapse-comment-threads",
+      post_appearance_type: "appearance--post-type",
+      use_system_dark_mode: "appearance--dark-use-system",
+      user_dark_mode: "appearance--dark-user-mode",
+    };
+
+    const settingsTable = tx.table("settings");
+
+    return await Promise.all(
+      Object.entries(localStorageMigrationKeys).map(
+        ([key, localStorageKey]) => {
+          const localStorageValue = localStorage.getItem(localStorageKey);
+
+          if (!localStorageValue) {
+            return Promise.resolve();
+          }
+
+          return settingsTable
+            .where(CompoundKeys.settings.key_and_user_handle_and_community)
+            .equals([key, "", ""])
+            .modify({
+              value: JSON.parse(localStorageValue),
+            });
+        }
+      )
+    );
+  }
+
+  async getSetting<T extends keyof SettingValueTypes>(
+    key: T,
+    specificity?: {
+      user_handle?: string;
+      community?: string;
+    }
+  ) {
+    const { user_handle = "", community = "" } = specificity || {};
+
+    const query = this.settings
+      .where(CompoundKeys.settings.key_and_user_handle_and_community)
+      .equals([key, user_handle, community]);
+
+    const setting = await query.first();
+
+    if (!setting) {
+      throw new Error(`Setting ${key} not found`);
+    }
+
+    return setting.value as SettingValueTypes[T];
+  }
+
+  async setSetting<T extends keyof SettingValueTypes>(
+    key: T,
+    value: SettingValueTypes[T],
+    specificity?: {
+      user_handle?: string;
+      community?: string;
+    }
+  ) {
+    const { user_handle = "", community = "" } = specificity || {};
+
+    this.transaction("rw", this.settings, async () => {
+      const query = this.settings
+        .where(CompoundKeys.settings.key_and_user_handle_and_community)
+        .equals([key, user_handle, community]);
+
+      const item = await query.first();
+
+      if (item) {
+        return await query.modify({ value });
+      }
+
+      return await this.settings.add({
+        key,
+        value,
+        user_handle,
+        community,
+      });
+    });
   }
 }
 

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -291,11 +291,15 @@ export class WefwefDB extends Dexie {
       }
 
       if (!setting && user_handle !== "" && community !== "") {
-        // Try to find the setting with user_handle only, community only and no specificity
+        // Try to find the setting with user_handle only, community only
         setting =
           (await this.findSetting(key, user_handle, "")) ||
-          (await this.findSetting(key, "", community)) ||
-          (await this.findSetting(key, "", ""));
+          (await this.findSetting(key, "", community));
+      }
+
+      if (!setting) {
+        // Try to find the global setting
+        setting = await this.findSetting(key, "", "");
       }
 
       if (!setting) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -6,7 +6,9 @@ import commentSlice from "./features/comment/commentSlice";
 import communitySlice from "./features/community/communitySlice";
 import userSlice from "./features/user/userSlice";
 import inboxSlice from "./features/inbox/inboxSlice";
-import appearanceSlice from "./features/settings/appearance/appearanceSlice";
+import appearanceSlice, {
+  fetchSettingsFromStorage,
+} from "./features/settings/appearance/appearanceSlice";
 
 const store = configureStore({
   reducer: {
@@ -24,5 +26,8 @@ export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;
 export const useAppDispatch: () => AppDispatch = useDispatch;
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
+
+// Load settings from DB into the store
+store.dispatch(fetchSettingsFromStorage());
 
 export default store;

--- a/src/store.ts
+++ b/src/store.ts
@@ -7,7 +7,7 @@ import communitySlice from "./features/community/communitySlice";
 import userSlice from "./features/user/userSlice";
 import inboxSlice from "./features/inbox/inboxSlice";
 import appearanceSlice, {
-  fetchSettingsFromStorage,
+  fetchSettingsFromDatabase,
 } from "./features/settings/appearance/appearanceSlice";
 
 const store = configureStore({
@@ -28,6 +28,6 @@ export const useAppDispatch: () => AppDispatch = useDispatch;
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
 
 // Load settings from DB into the store
-store.dispatch(fetchSettingsFromStorage());
+store.dispatch(fetchSettingsFromDatabase());
 
 export default store;


### PR DESCRIPTION
This pr moves existing settings to dexie. It also adds support for any combination of user/community specific settings so we can implement some settings in a standard way. Using string keys might look weird but they're fully protected by TS so it's not possible to make a typo with those. Values are also typed per key so should be pretty safe.

Things to test:
- User installing the app for the first time.
- User updating the app from a pre-Dexie version.
- User updating the app from the last version of the DB.
- Regular flow, changing settings, seeing results of those settings

I tested these scenarios and couldn't find any issues but it's better to have another set of eyes check it. 