### PR TITLE
Fix safari/ios 13

### DIFF
--- a/src/helpers/useSystemDarkMode.ts
+++ b/src/helpers/useSystemDarkMode.ts
@@ -7,20 +7,27 @@ export default function useSystemDarkMode() {
     window.matchMedia(DARK_MEDIA_SELECTOR).matches
   );
 
+  const mediaQuery = window
+    .matchMedia(DARK_MEDIA_SELECTOR);
+
   useEffect(() => {
     function handleDarkModeChange() {
-      const doesMatch = window.matchMedia(DARK_MEDIA_SELECTOR).matches;
+      const doesMatch = mediaQuery.matches;
       setPrefersDarkMode(doesMatch);
     }
 
-    window
-      .matchMedia(DARK_MEDIA_SELECTOR)
-      .addEventListener("change", handleDarkModeChange);
+    if (mediaQuery?.addEventListener) {
+      mediaQuery.addEventListener("change", handleDarkModeChange);
+    } else {
+      mediaQuery.addListener(handleDarkModeChange);
+    }
 
     return () => {
-      window
-        .matchMedia(DARK_MEDIA_SELECTOR)
-        .removeEventListener("change", handleDarkModeChange);
+      if (mediaQuery?.removeEventListener) {
+        mediaQuery.removeEventListener("change", handleDarkModeChange);
+      } else {
+        mediaQuery.removeListener(handleDarkModeChange);
+      }
     };
   }, []);
 

--- a/src/helpers/useSystemDarkMode.ts
+++ b/src/helpers/useSystemDarkMode.ts
@@ -7,9 +7,9 @@ export default function useSystemDarkMode() {
     window.matchMedia(DARK_MEDIA_SELECTOR).matches
   );
 
-  const mediaQuery = window.matchMedia(DARK_MEDIA_SELECTOR);
-
   useEffect(() => {
+    const mediaQuery = window.matchMedia(DARK_MEDIA_SELECTOR);
+
     function handleDarkModeChange() {
       const doesMatch = mediaQuery.matches;
       setPrefersDarkMode(doesMatch);
@@ -30,7 +30,7 @@ export default function useSystemDarkMode() {
         mediaQuery.removeListener(handleDarkModeChange);
       }
     };
-  }, [mediaQuery]);
+  }, []);
 
   return prefersDarkMode;
 }

--- a/src/helpers/useSystemDarkMode.ts
+++ b/src/helpers/useSystemDarkMode.ts
@@ -16,6 +16,8 @@ export default function useSystemDarkMode() {
       setPrefersDarkMode(doesMatch);
     }
 
+    // Fallback to addListener/removeListener for older browser support
+    // See https://github.com/aeharding/wefwef/pull/264
     if (mediaQuery?.addEventListener) {
       mediaQuery.addEventListener("change", handleDarkModeChange);
     } else {

--- a/src/helpers/useSystemDarkMode.ts
+++ b/src/helpers/useSystemDarkMode.ts
@@ -7,8 +7,7 @@ export default function useSystemDarkMode() {
     window.matchMedia(DARK_MEDIA_SELECTOR).matches
   );
 
-  const mediaQuery = window
-    .matchMedia(DARK_MEDIA_SELECTOR);
+  const mediaQuery = window.matchMedia(DARK_MEDIA_SELECTOR);
 
   useEffect(() => {
     function handleDarkModeChange() {
@@ -31,7 +30,7 @@ export default function useSystemDarkMode() {
         mediaQuery.removeListener(handleDarkModeChange);
       }
     };
-  }, []);
+  }, [mediaQuery]);
 
   return prefersDarkMode;
 }


### PR DESCRIPTION
Fixes regression from https://github.com/aeharding/wefwef/pull/74

Application fails to load (blank page) with error `mediaMatch().addEventListener is not a function`.

See also: https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList#browser_compatibility