### PR TITLE
Update docker build to target arm64 rather than arm/v8

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,7 +38,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          platforms: linux/amd64,linux/arm/v8
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.metal.outputs.tags }}
           labels: ${{ steps.metal.outputs.labels }}


### PR DESCRIPTION
addresses https://github.com/aeharding/wefwef/issues/253

Like `amd64`, the variant can be left off as `v8` is the default for `arm64`. This should make the GitHub action build something that would work on an M1 laptop (`aarch64` is also normalized to `arm64` by buidkit)