### PR TITLE
Fix desktop saved post/comment indicator position

### DIFF
--- a/src/features/comment/Comment.tsx
+++ b/src/features/comment/Comment.tsx
@@ -42,6 +42,8 @@ export const PositionedContainer = styled.div<{
   depth: number;
   highlighted: boolean;
 }>`
+  position: relative;
+
   ${maxWidthCss}
 
   padding: 0.55rem 1rem;
@@ -276,8 +278,8 @@ export default function Comment({
                 </Content>
               </AnimateHeight>
             </Container>
+            <Save type="comment" id={commentView.comment.id} />
           </PositionedContainer>
-          <Save type="comment" id={commentView.comment.id} />
         </CustomIonItem>
       </SlidingNestedCommentVote>
     </AnimateHeight>

--- a/src/features/post/inFeed/Post.tsx
+++ b/src/features/post/inFeed/Post.tsx
@@ -10,7 +10,6 @@ import { getHandle } from "../../../helpers/lemmy";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { postHiddenByIdSelector, hidePost, unhidePost } from "../postSlice";
 import AnimateHeight from "react-animate-height";
-import Save from "../../labels/Save";
 
 const CustomIonItem = styled(IonItem)`
   --padding-start: 0;
@@ -94,7 +93,6 @@ export default function Post(props: PostProps) {
           href={undefined}
         >
           {postBody}
-          <Save type="post" id={props.post.post.id} />
         </CustomIonItem>
       </SlidingVote>
     </AnimateHeight>

--- a/src/features/post/inFeed/compact/CompactPost.tsx
+++ b/src/features/post/inFeed/compact/CompactPost.tsx
@@ -7,6 +7,7 @@ import MoreActions from "../../shared/MoreActions";
 import PersonLink from "../../../labels/links/PersonLink";
 import CommunityLink from "../../../labels/links/CommunityLink";
 import { VoteButton } from "../../shared/VoteButton";
+import Save from "../../../labels/Save";
 
 const Container = styled.div`
   display: flex;
@@ -14,6 +15,8 @@ const Container = styled.div`
   padding: 12px;
   gap: 12px;
   line-height: 1.15;
+
+  position: relative;
 
   ${maxWidthCss}
 `;
@@ -89,6 +92,8 @@ export default function CompactPost({ post, communityMode }: PostProps) {
         <VoteButton type="up" postId={post.post.id} />
         <VoteButton type="down" postId={post.post.id} />
       </EndDetails>
+
+      <Save type="post" id={post.post.id} />
     </Container>
   );
 }

--- a/src/features/post/inFeed/large/LargePost.tsx
+++ b/src/features/post/inFeed/large/LargePost.tsx
@@ -16,6 +16,7 @@ import { AnnouncementIcon } from "../../detail/PostDetail";
 import CommunityLink from "../../../labels/links/CommunityLink";
 import Video from "../../../shared/Video";
 import { PostProps } from "../Post";
+import Save from "../../../labels/Save";
 
 const Container = styled.div`
   display: flex;
@@ -23,6 +24,8 @@ const Container = styled.div`
   width: 100%;
   gap: 0.75rem;
   padding: 0.75rem;
+
+  position: relative;
 
   ${maxWidthCss}
 `;
@@ -208,6 +211,8 @@ export default function LargePost({ post, communityMode }: PostProps) {
           <VoteButton type="down" postId={post.post.id} />
         </RightDetails>
       </Details>
+
+      <Save type="post" id={post.post.id} />
     </Container>
   );
 }


### PR DESCRIPTION
**This should not result in any changes for mobile devices.**

Changes for desktop below:

Before:

![Screenshot 2023-07-04 at 22-51-54 wefwef for lemmy](https://github.com/aeharding/wefwef/assets/2166114/9e3d39d6-e073-446c-8b16-012e153f2c97)

After:

![Screenshot 2023-07-04 at 22-51-40 wefwef for lemmy](https://github.com/aeharding/wefwef/assets/2166114/0f8792d6-bc08-4fab-bb45-de74342729e8)
