### PR TITLE
Fix posts hidden not appearing on profile

### DIFF
--- a/src/features/user/Profile.tsx
+++ b/src/features/user/Profile.tsx
@@ -108,7 +108,13 @@ export default function Profile({ person }: ProfileProps) {
     [person, buildGeneralBrowseLink, isSelf]
   );
 
-  return <PostCommentFeed fetchFn={fetchFn} header={header} />;
+  return (
+    <PostCommentFeed
+      fetchFn={fetchFn}
+      header={header}
+      filterHiddenPosts={false}
+    />
+  );
 }
 
 function getCreatedDate(item: PostCommentItem): number {

--- a/src/pages/profile/ProfileFeedItemsPage.tsx
+++ b/src/pages/profile/ProfileFeedItemsPage.tsx
@@ -86,7 +86,7 @@ export default function ProfileFeedItemsPage({
         </IonToolbar>
       </IonHeader>
       <IonContent>
-        <PostCommentFeed fetchFn={fetchFn} />
+        <PostCommentFeed fetchFn={fetchFn} filterHiddenPosts={false} />
       </IonContent>
     </IonPage>
   );


### PR DESCRIPTION
Resolves #283

NOTE: You can technically "swipe" away an item from profile still.

However, in #64 we will have custom profile swipe actions where swipe to hide is not an option on the profile.