### PR TITLE
Add UNPROXIED_LEMMY_SERVERS to configure bypassing the proxy

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -2,6 +2,10 @@ import express from "express";
 import ViteExpress from "vite-express";
 import { createProxyMiddleware } from "http-proxy-middleware";
 
+const UNPROXIED_LEMMY_SERVERS = process.env.UNPROXIED_LEMMY_SERVERS
+  ? process.env.UNPROXIED_LEMMY_SERVERS.split(",").map((s) => s.trim())
+  : [];
+
 const CUSTOM_LEMMY_SERVERS = process.env.CUSTOM_LEMMY_SERVERS
   ? process.env.CUSTOM_LEMMY_SERVERS.split(",").map((s) => s.trim())
   : [];
@@ -136,7 +140,13 @@ function transformer(html) {
       CUSTOM_LEMMY_SERVERS.length
         ? `window.CUSTOM_LEMMY_SERVERS = ${JSON.stringify(
             CUSTOM_LEMMY_SERVERS
-          )}`
+          )};`
+        : ""
+    }${
+      UNPROXIED_LEMMY_SERVERS.length
+        ? `window.UNPROXIED_LEMMY_SERVERS = ${JSON.stringify(
+            UNPROXIED_LEMMY_SERVERS
+          )};`
         : ""
     }</script>`
   );

--- a/src/helpers/lemmy.ts
+++ b/src/helpers/lemmy.ts
@@ -10,6 +10,21 @@ export const LEMMY_SERVERS =
     ? (window.CUSTOM_LEMMY_SERVERS as string[])
     : ["lemmy.world", "lemmy.ml", "beehaw.org", "sh.itjust.works"];
 
+export const UNPROXIED_LEMMY_SERVERS =
+  "UNPROXIED_LEMMY_SERVERS" in window
+    ? (window.UNPROXIED_LEMMY_SERVERS as string[])
+    : [
+        "lemmy.ml",
+        "beehaw.org",
+        "sh.itjust.works",
+        "lemm.ee",
+        "feddit.de",
+        "midwest.social",
+        "lemmynsfw.com",
+        "lemmy.ca",
+        "lemmy.sdf.org",
+      ];
+
 export interface LemmyJWT {
   sub: number;
   iss: string; // e.g. "lemmy.ml"

--- a/src/services/lemmy.ts
+++ b/src/services/lemmy.ts
@@ -1,10 +1,11 @@
 import { LemmyHttp } from "lemmy-js-client";
 import { reduceFileSize } from "../helpers/imageCompress";
+import { UNPROXIED_LEMMY_SERVERS } from "../helpers/lemmy";
 
 function buildBaseUrl(url: string): string {
-  // if (url === "lemmy.world") {
-  //   return `https://lemmy.world`;
-  // }
+  if (UNPROXIED_LEMMY_SERVERS.includes(url)) {
+    return `https://${url}`;
+  }
 
   return `${location.origin}/api/${url}`;
 }


### PR DESCRIPTION
Since https://github.com/LemmyNet/lemmy/pull/3421 was merged, Lemmy
instances on 0.18.1 and newer allow cross-origin requests.

Expose an environment variable, UNPROXIED_LEMMY_SERVERS to support
updated servers. We use an allow-list to maintain maximum backward
compatibility while servers start to upgrade.