### PR TITLE
Fix for issue #323: Clicking the posts button now correctly scrolls to top of the page.

### DIFF
--- a/src/TabbedRoutes.tsx
+++ b/src/TabbedRoutes.tsx
@@ -154,8 +154,8 @@ export default function TabbedRoutes() {
       return new Promise((resolve) =>
         activePage.current?.getState((state) => {
           if (state.scrollTop) {
-            activePage.current?.scrollTo({
-              top: 0,
+            activePage.current?.scrollToIndex({
+              index: 0,
               behavior: "smooth",
             });
           }


### PR DESCRIPTION
fix for issue #323 