### PR TITLE
Support bypassing the proxy for some Lemmy instances

### DIFF
--- a/src/services/lemmy.ts
+++ b/src/services/lemmy.ts
@@ -1,10 +1,22 @@
 import { LemmyHttp } from "lemmy-js-client";
 import { reduceFileSize } from "../helpers/imageCompress";
 
+const UNPROXIED_LEMMY_SERVERS = [
+  "lemmy.ml",
+  "beehaw.org",
+  "sh.itjust.works",
+  "lemm.ee",
+  "feddit.de",
+  "midwest.social",
+  "lemmynsfw.com",
+  "lemmy.ca",
+  "lemmy.sdf.org",
+];
+
 function buildBaseUrl(url: string): string {
-  // if (url === "lemmy.world") {
-  //   return `https://lemmy.world`;
-  // }
+  if (UNPROXIED_LEMMY_SERVERS.includes(url)) {
+    return `https://${url}`;
+  }
 
   return `${location.origin}/api/${url}`;
 }

--- a/src/services/lemmy.ts
+++ b/src/services/lemmy.ts
@@ -18,6 +18,10 @@ function buildBaseUrl(url: string): string {
     return `https://${url}`;
   }
 
+  return buildProxiedBaseUrl(url);
+}
+
+function buildProxiedBaseUrl(url: string): string {
   return `${location.origin}/api/${url}`;
 }
 
@@ -49,8 +53,10 @@ export async function uploadImage(url: string, auth: string, image: File) {
 
   formData.append("images[]", compressedImageIfNeeded);
 
+  // All requests for image upload must be proxied due to Lemmy not accepting
+  // parameterized JWT for this request (see: https://github.com/LemmyNet/lemmy/issues/3567)
   const response = await fetch(
-    `${buildBaseUrl(url)}${PICTRS_URL}?${new URLSearchParams({ auth })}`,
+    `${buildProxiedBaseUrl(url)}${PICTRS_URL}?${new URLSearchParams({ auth })}`,
     {
       method: "POST",
       body: formData,


### PR DESCRIPTION
Since LemmyNet/lemmy#3421 was merged, Lemmy instances on 0.18.1 and newer allow cross-origin requests.


Notably missing is lemmy.world, which currently is broken as it sends double CORS headers:
```js
> fetch('https://lemmy.world/api/v3/posts/list');
```

> Access to fetch at 'https://lemmy.world/api/v3/posts/list' from origin 'https://wefwef.app' has been blocked by CORS policy: The 'Access-Control-Allow-Origin' header contains multiple values 'https://wefwef.app, *', but only one is allowed. Have the server send the header with a valid value, or, if an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
